### PR TITLE
handle issue with preview url effecting images in RTEs

### DIFF
--- a/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
+++ b/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
@@ -15,7 +15,13 @@ class EnvironmentOverrides {
 		result.environment = serverProperties["environment"] 
 		result.previewServerUrl = serverProperties["previewUrl"]
 		if(result.previewServerUrl.equals("\${previewUrl}")){
-			result.previewServerUrl=request.scheme+"://"+request.serverName+":"+request.serverPort;
+
+			if("80".equals(request.serverPort) ||  "443".equals(request.serverPort)) {	
+				result.previewServerUrl=request.scheme+"://"+request.serverName
+			}
+			else {
+				result.previewServerUrl=request.scheme+"://"+request.serverName+":"+request.serverPort
+			}
 		}
 		try {		
 			result.user = SecurityServices.getCurrentUser(context)


### PR DESCRIPTION
Browser does not include port number when ports are standard (80 and 443)
