### PR TITLE
CRAFTERCMS-1870 Saving a content type from Admin Console breaks form-definition.xml in IE 11

### DIFF
--- a/src/main/webapp/default-site/static-assets/components/cstudio-admin/mods/content-types.js
+++ b/src/main/webapp/default-site/static-assets/components/cstudio-admin/mods/content-types.js
@@ -121,6 +121,7 @@ YAHOO.extend(CStudioAdminConsole.Tool.ContentTypes, CStudioAdminConsole.Tool, {
                                     var url = "/api/1/services/api/1/site/write-configuration.json" +
                                         "?path=" + defPath;
 
+									YAHOO.util.Connect.resetFormState();
                                     YAHOO.util.Connect.setDefaultPostHeader(false);
                                     YAHOO.util.Connect.initHeader("Content-Type", "application/xml; charset=utf-8");
                                     YAHOO.util.Connect.asyncRequest('POST', CStudioAuthoring.Service.createServiceUri(url), cb, xml);


### PR DESCRIPTION
CRAFTERCMS-1870
Saving a content type from Admin Console breaks form-definition.xml in IE 11
