### PR TITLE
CRAFTERCMS-1878 - content on dashboard tries to load .xml instead of html file on editor

### DIFF
--- a/src/main/webapp/default-site/static-assets/components/cstudio-common/common-api.js
+++ b/src/main/webapp/default-site/static-assets/components/cstudio-common/common-api.js
@@ -1035,8 +1035,9 @@ var ApproveType = false;
                 var filename = (contentTO.pathSegment) ? contentTO.pathSegment : contentTO.name;
 
                 if (CStudioAuthoring.Utils.endsWith(filename, ".xml")) {
-
                     url = CStudioAuthoringContext.previewAppBaseUri + contentTO.browserUri;
+                    url = url.replace('.xml', '.html');
+
                     if (contentTO.document && contentTO.assets && contentTO.assets.length == 1) {
                         url = CStudioAuthoringContext.previewAppBaseUri + contentTO.assets[0].uri;
                     }

--- a/src/main/webapp/default-site/static-assets/components/cstudio-forms/forms-engine.js
+++ b/src/main/webapp/default-site/static-assets/components/cstudio-forms/forms-engine.js
@@ -911,6 +911,15 @@ var CStudioForms = CStudioForms || function() {
                      * See file-name.js function _onChange().
                      */
 
+                    if(form.definition.objectType == "page"){
+                        var pagePath = entityId.replace('/site/website/', '');
+                        file = pagePath.split("/").pop();
+
+                        if(file != "index.xml") {
+                            folderName = "";
+                        }
+                    }
+
                     if (changeTemplate == "true") {
                         if (form.definition.contentAsFolder == "false") {
                             entityId = entityId.replace("/index.xml");


### PR DESCRIPTION
CRAFTERCMS-1878 - content on dashboard tries to load .xml instead of html file on editor

and issue with creation of folders for single xml files
