### PR TITLE
CRAFTERCMS-1133 Form: RTE: the cursor disappears when switching back to WYSIWYG

### DIFF
--- a/src/main/webapp/default-site/static-assets/components/cstudio-forms/controls/rte-plugins/edit-html.js
+++ b/src/main/webapp/default-site/static-assets/components/cstudio-forms/controls/rte-plugins/edit-html.js
@@ -215,9 +215,11 @@ CStudioAuthoring.Module.requireModule(
 				editor.getWin().scrollTo(0, 0); // Scroll to the top of the editor window
 
 				rteControl.clearTextEditorSelection();
-				editor.focus();
 
 				rteControl.scrollToTopOfElement(rteControl.containerEl, 30);
+
+				editor.contentWindow.frameElement.focus();
+				$(editor.contentWindow.frameElement).contents().find("body").focus();
 			},
 
 			createControl: function(n, cm) {


### PR DESCRIPTION
CRAFTERCMS-1133 - Form: RTE: the cursor disappears when switching back to WYSIWYG
