### PR TITLE
Updated pom.xml and .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ crafter-studio-2.iml
 crafter/*
 data/*
 derby.log
+
+deploy/*

--- a/pom.xml
+++ b/pom.xml
@@ -503,9 +503,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9</version>
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -574,6 +571,33 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>JDK8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.4</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <additionalparam>-Xdoclint:none</additionalparam>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>test</id>
             <build>


### PR DESCRIPTION
pom.xml: added support for Java 1.8 and 1.7 regarding JavaDoc build issue under 1.8.

.gitignore: added deploy/\* to the ignore list to help with dev setup.
