### PR TITLE
Change 'No content type configuration document' to a debug'

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/configuration/ContentTypesConfigImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/configuration/ContentTypesConfigImpl.java
@@ -141,7 +141,7 @@ public class ContentTypesConfigImpl implements ContentTypesConfig {
             contentTypeConfig.setType(getContentTypeTypeByName(name));
             return contentTypeConfig;
         } else {
-            logger.error("No content type configuration document found at " + configFileFullPath);
+            logger.debug("No content type configuration document found at " + configFileFullPath);
             return null;
         }
     }


### PR DESCRIPTION
Debug utils printing stack trace renders other debug comments unusable.