### PR TITLE
Crafter 3.0 Work

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/service/deployment/DeploymentService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/deployment/DeploymentService.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * Crafter Studio Web-content authoring solution
  *     Copyright (C) 2007-2016 Crafter Software Corporation.
- * 
+ *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     This program is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************/
@@ -85,6 +85,4 @@ public interface DeploymentService {
     void bulkDelete(String site, String path);
 
     List<DeploymentJobTO> getDeploymentJobs();
-
-    boolean createPreviewTarget(String site);
 }

--- a/src/main/java/org/craftercms/studio/api/v1/service/search/SearchService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/search/SearchService.java
@@ -14,4 +14,12 @@ public interface SearchService {
 	 * @throws ServiceException
 	 */
 	void createIndex(String siteId) throws ServiceException;
+
+	/**
+	 * Delete a search index (core) in Crafter Search for a site
+	 *
+	 * @param siteId the Site ID for the site to delete the index for
+	 * @throws ServiceException
+	 */
+	public void deleteIndex(final String siteId) throws ServiceException;
 }

--- a/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
@@ -159,6 +159,7 @@ public interface StudioConfiguration {
 
     /** Preview Search **/
     String PREVIEW_SEARCH_CREATE_URL = "studio.preview.search.createUrl";
+    String PREVIEW_SEARCH_DELETE_URL = "studio.preview.search.deleteUrl";
 
     /** Publishing Manager */
     String PUBLISHING_MANAGER_INDEX_FILE = "studio.publishingManager.indexFile";

--- a/src/main/java/org/craftercms/studio/impl/v1/deployment/PreviewDeployerImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/deployment/PreviewDeployerImpl.java
@@ -19,6 +19,7 @@
 package org.craftercms.studio.impl.v1.deployment;
 
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
@@ -33,11 +34,6 @@ import org.craftercms.studio.api.v1.util.StudioConfiguration;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringTokenizer;
 
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.*;
 
@@ -95,7 +91,7 @@ public class PreviewDeployerImpl implements PreviewDeployer {
         HttpClient client = new HttpClient();
         try {
             int status = client.executeMethod(postMethod);
-            if (status != 200) {
+            if (status != HttpStatus.SC_CREATED) {
                 toReturn = false;
             }
         } catch (IOException e) {

--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -574,7 +574,7 @@ public class ContentServiceImpl implements ContentService {
         item.browserUri = contentPath;
 
         if(item.page) {
-            // TODO: SJ: This is hokey, fix in 2.7.x
+            // TODO: SJ: This is hokey, fix in 4.x
             item.browserUri = contentPath.replace("/site/website", "").replace("/index.xml", "");
         }
 

--- a/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DeploymentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DeploymentServiceImpl.java
@@ -829,11 +829,6 @@ public class DeploymentServiceImpl implements DeploymentService {
         dmPublishService.bulkDelete(site, path);
     }
 
-    @Override
-    public boolean createPreviewTarget(String site) {
-        return eventService.firePreviewCreateTargetEvent(site);
-    }
-
     public void setServicesConfig(ServicesConfig servicesConfig) {
         this.servicesConfig = servicesConfig;
     }

--- a/src/main/java/org/craftercms/studio/impl/v1/service/search/SearchServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/search/SearchServiceImpl.java
@@ -18,6 +18,7 @@ import org.craftercms.studio.api.v1.service.search.SearchService;
 import org.craftercms.studio.api.v1.util.StudioConfiguration;
 
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_SEARCH_CREATE_URL;
+import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_SEARCH_DELETE_URL;
 
 /**
  * Created by Sumer Jabri on 2/15/17.
@@ -50,13 +51,49 @@ public class SearchServiceImpl implements SearchService {
 		HttpClient client = new HttpClient();
 		try {
 			int status = client.executeMethod(postMethod);
-			if (status != HttpStatus.SC_OK) {
+			if (status != HttpStatus.SC_CREATED) {
 				throw new ServiceException("Error while creating search index for site " + siteId + ". Response: "
 					+ postMethod.getResponseBodyAsString());
 			}
 		} catch (IOException e) {
 			logger.error("Error while creating search index for site " + siteId, e);
 			throw new ServiceException("Error while creating search index for site " + siteId, e);
+		} finally {
+			postMethod.releaseConnection();
+		}
+	}
+
+	@Override
+	public void deleteIndex(final String siteId) throws ServiceException {
+		String requestUrl = studioConfiguration.getProperty(PREVIEW_SEARCH_DELETE_URL);
+
+		PostMethod postMethod = new PostMethod(requestUrl);
+		postMethod.getParams().setBooleanParameter(HttpMethodParams.USE_EXPECT_CONTINUE, true);
+		String rqBody = "{ \"id\" : \"" + siteId + "\" }";  // TODO: SJ: Replace this with something better
+		RequestEntity requestEntity = null;
+
+		try {
+			requestEntity = new StringRequestEntity(rqBody, ContentType.APPLICATION_JSON.toString(), StandardCharsets.UTF_8.displayName());
+		} catch (UnsupportedEncodingException e) {
+			logger.info("Unsupported encoding for request body. Using deprecated method instead.");
+		}
+		if (requestEntity != null) {
+			postMethod.setRequestEntity(requestEntity);
+		} else {
+			postMethod.setRequestBody(rqBody);
+		}
+
+		// TODO: SJ: Review exception handling
+		HttpClient client = new HttpClient();
+		try {
+			int status = client.executeMethod(postMethod);
+			if (status != HttpStatus.SC_NO_CONTENT) {
+				throw new ServiceException("Error while deleting search index for site " + siteId + ". Response: "
+					+ postMethod.getResponseBodyAsString());
+			}
+		} catch (IOException e) {
+			logger.error("Error while deleting search index for site " + siteId, e);
+			throw new ServiceException("Error while deleting search index for site " + siteId, e);
 		} finally {
 			postMethod.releaseConnection();
 		}

--- a/src/main/resources/crafter/studio/extension/services-overlay-context.xml
+++ b/src/main/resources/crafter/studio/extension/services-overlay-context.xml
@@ -115,6 +115,9 @@
     <bean id="crafter.analyticsService" class="org.craftercms.studio.impl.v1.GoogleAnalyticsServiceImpl">
     </bean>
 
+    <bean id="crafter.searchService" class="org.craftercms.search.service.impl.SolrRestClientSearchService">
+        <property name="serverUrl" value="${crafter.engine.search.server.url}"/>
+    </bean>
 
     <!-- ////////////////////////////////// -->
     <!--                                    -->

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -305,6 +305,7 @@ studio.preview.disableDeployCron: true
 ##                   Preview Search                       ##
 ############################################################
 studio.preview.search.createUrl: http://localhost:8080/search/api/2/admin/index/create
+studio.preview.search.deleteUrl: http://localhost:8080/search/api/2/admin/index/delete
 
 ############################################################
 ##                   Publishing Manager                   ##

--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -79,6 +79,7 @@
         <property name="studioConfiguration" ref="studioConfiguration"/>
         <property name="searchService" ref="searchService" />
         <property name="eventService" ref="studioEventService"/>
+        <property name="previewDeployer" ref="previewDeployer"/>
     </bean>
 
     <bean id="cstudioImportService" class="org.craftercms.studio.impl.v1.service.content.ImportServiceImpl">

--- a/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/config/studio/role-mappings-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/config/studio/role-mappings-config.xml
@@ -4,17 +4,17 @@
         <group name="crafter-admin">
             <role>admin</role>
         </group>
-        <group name="crafter_editorial_admin">
+        <group name="crafter_{siteName}_admin">
             <role>admin</role>
         </group>
         <group name="crafter-author">
             <role>author</role>
         </group>
-        <group name="crafter_editorial_author">
+        <group name="crafter_{siteName}_author">
             <role>author</role>
         </group>
-        <group name="crafter_editorial_viewer">
+        <group name="crafter_{siteName}_viewer">
             <role>viewer</role>
-        </group>         
+        </group>
     </groups>
 </role-mappings>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/config/studio/site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/config/studio/site-config.xml
@@ -1,8 +1,8 @@
 <!-- Example site configuration -->
 <site-config>
-    <wem-project>editorial</wem-project>
-    <name>editorial</name>
-    <display-name>editorial</display-name>
+    <wem-project>{siteName}</wem-project>
+    <name>{siteName}</name>
+    <display-name>{siteName}</display-name>
     <default-timezone>EST5EDT</default-timezone>
     <default-content-type/>
     <namespace-to-type-map>
@@ -80,6 +80,8 @@
             <display-in-widget-pattern>/site/components/([^&lt;]+).xml</display-in-widget-pattern>
             <display-in-widget-pattern>/static-assets/([^&lt;"'\)]+)</display-in-widget-pattern>
             <display-in-widget-pattern>/templates/([^&lt;"]+)\.ftl</display-in-widget-pattern>
+            <display-in-widget-pattern>/scripts/([^&lt;"]+)\.groovy</display-in-widget-pattern>
+            <display-in-widget-pattern>/config/([^&lt;"]+)\.xml</display-in-widget-pattern>
         </display-in-widget-patterns>
         <common-prototype-config>
 


### PR DESCRIPTION
Changed site creation flow to first create the search index, then the preview deployment target and finally create the site in repo and sync. Failure of any part will result in a rollback of other components.
Updated the Editorial Blueprint with better initial configuration. (In progress.)