### PR TITLE
Backwards compatibility for permissions configuration files

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/security/SecurityServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/security/SecurityServiceImpl.java
@@ -441,7 +441,15 @@ public class SecurityServiceImpl implements SecurityService {
     protected void loadPermissions(String siteId, Element root, PermissionsConfigTO config) {
         if (root.getName().equals(StudioXmlConstants.DOCUMENT_PERMISSIONS)) {
             Map<String, Map<String, List<Node>>> permissionsMap = new HashMap<String, Map<String, List<Node>>>();
-            List<Node> roleNodes = root.selectNodes(StudioXmlConstants.DOCUMENT_ELM_PERMISSION_ROLE);
+
+            //backwards compatibility for nested <site>
+            Element permissionsRoot = root;
+            Element siteNode = (Element) permissionsRoot.selectSingleNode(StudioXmlConstants.DOCUMENT_ELM_SITE);
+            if(siteNode != null) {
+                permissionsRoot = siteNode;
+            }
+
+            List<Node> roleNodes = permissionsRoot.selectNodes(StudioXmlConstants.DOCUMENT_ELM_PERMISSION_ROLE);
             Map<String, List<Node>> rules = new HashMap<String, List<Node>>();
             for (Node roleNode : roleNodes) {
                 String roleName = roleNode.valueOf(StudioXmlConstants.DOCUMENT_ATTR_PERMISSIONS_NAME);


### PR DESCRIPTION
Commit f933ff0da77edc2f7f718bbd3bbb3e5365164374 to master on Studio changed the Permissions Mapping configuration structure to remove the nested site element. This change provides backwards compatibility for existing sites using the previous configuration hierarchy, while still supporting the new, preferred hierarchy.