### PR TITLE
Group name can now be extracted also with the LDAP site ID regex

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
@@ -139,6 +139,7 @@ public interface StudioConfiguration {
     String SECURITY_LDAP_USER_ATTRIBUTE_SITE_ID = "studio.security.ldap.userAttribute.siteId";
     String SECURITY_LDAP_USER_ATTRIBUTE_SITE_ID_REGEX = "studio.security.ldap.userAttribute.siteId.regex";
     String SECURITY_LDAP_USER_ATTRIBUTE_SITE_ID_MATCH_INDEX = "studio.security.ldap.userAttribute.siteId.matchIndex";
+    String SECURITY_LDAP_USER_ATTRIBUTE_SITE_ID_GROUP_NAME_MATCH_INDEX = "studio.security.ldap.userAttribute.siteId.groupName.matchIndex";
     String SECURITY_LDAP_USER_ATTRIBUTE_GROUP_NAME = "studio.security.ldap.userAttribute.groupName";
     String SECURITY_LDAP_USER_ATTRIBUTE_GROUP_NAME_REGEX = "studio.security.ldap.userAttribute.groupName.regex";
     String SECURITY_LDAP_USER_ATTRIBUTE_GROUP_NAME_MATCH_INDEX = "studio.security.ldap.userAttribute.groupName.matchIndex";

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -197,6 +197,8 @@ studio.security.ldap.userAttribute.siteId: crafterSite
 studio.security.ldap.userAttribute.siteId.regex: .*
 # LDAP site ID attribute match index
 studio.security.ldap.userAttribute.siteId.matchIndex: 0
+# LDAP group name match index for the site ID attribute
+studio.security.ldap.userAttribute.siteId.groupName.matchIndex: 1
 # LDAP groups attribute
 studio.security.ldap.userAttribute.groupName: crafterGroup
 # LDAP groups attribute name regex


### PR DESCRIPTION
Group name can now be extracted also with the LDAP site ID regex, to allow for users to have specific site/groups.

Ticket craftercms/craftercms#2150