### PR TITLE
SSO logout fixes:

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/constant/StudioConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v1/constant/StudioConstants.java
@@ -56,7 +56,7 @@ package org.craftercms.studio.api.v1.constant;
    String PATTERN_SANDBOX = "\\$\\{sandbox\\}";
    String PATTERN_SITE = "\\{site\\}";
    String PATTERN_WEB_PROJECT = "\\$\\{webproject\\}";
-   String PATTERN_LOGIN_URL = "\\{loginUrl\\}";
+   String PATTERN_BASE_URL = "\\{baseUrl\\}";
 
    /** Studio Structure Constants **/
    String DESCRIPTOR_ROOT_PATH  = "/site";
@@ -165,11 +165,6 @@ package org.craftercms.studio.api.v1.constant;
      * Session attributes
      */
     String HTTP_SESSION_ATTRIBUTE_AUTHENTICATION = "studio_authentication";
-
-    /**
-     * Login constants
-     */
-    String LOGIN_URL = "#/login";
 
     int DEFAULT_ORGANIZATION_ID = 1;
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
@@ -88,8 +88,8 @@ public class ConfigurationServiceImpl implements ConfigurationService {
             RequestContext requestContext = RequestContext.getCurrent();
 
             if (requestContext != null) {
-                String loginUrl = HttpUtils.getFullUrl(requestContext.getRequest(), LOGIN_URL);
-                logoutUrl = logoutUrl.replaceFirst(PATTERN_LOGIN_URL, loginUrl);
+                String baseUrl = HttpUtils.getFullUrl(requestContext.getRequest(), "");
+                logoutUrl = logoutUrl.replaceFirst(PATTERN_BASE_URL, baseUrl);
             }
 
             return logoutUrl;

--- a/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
@@ -118,10 +118,6 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         return studioConfiguration.getProperty(AUTHENTICATION_HEADERS_LOGOUT_URL);
     }
 
-    private String getAuthenticationHeadersLogoutMethod() {
-        return studioConfiguration.getProperty(AUTHENTICATION_HEADERS_LOGOUT_METHOD);
-    }
-
     @Required
     public void setContentService(ContentService contentService) {
         this.contentService = contentService;

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -221,9 +221,10 @@ studio.authentication.headers.email: email
 studio.authentication.headers.groups: groups
 # Enable/disable logout for headers authenticated users (SSO)
 studio.authentication.headers.logout.enabled: false
-# If logout is enabled for headers authenticated users (SSO), set the URL where SP (Service Provider) logout is provided
-# (to be called after local logout)
-studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={loginUrl}
+# If logout is enabled for headers authenticated users (SSO), set the endpoint of the SP or IdP logout, which should
+# be called after local logout. The {baseUrl} macro is provided so that the browser is redirected back to Studio
+# after logout (https://STUDIO_SERVER:STUDIO_PORT/studio)
+studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={baseUrl}
 
 ###############################################################
 ##               Page Navigation Order Service               ##

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -223,7 +223,7 @@ studio.authentication.headers.groups: groups
 studio.authentication.headers.logout.enabled: false
 # If logout is enabled for headers authenticated users (SSO), set the URL where SP (Service Provider) logout is provided
 # (to be called after local logout)
-studio.authentication.headers.logout.url: /mellon/logout?RedirectTo={loginUrl}
+studio.authentication.headers.logout.url: /mellon/logout?ReturnTo={loginUrl}
 
 ###############################################################
 ##               Page Navigation Order Service               ##


### PR DESCRIPTION
* Fixed SSO logout URL, default mod_auth_mellon param is ReturnTo.
* Changed {loginUrl} to {baseUrl} since in SSO it doesn't make sense to redirect to the Studio login page.

Ticket craftercms/craftercms#2500