### PR TITLE
Add german as available language option to Crafter Studio

### DIFF
--- a/src/main/webapp/default-site/scripts/rest/api/1/server/get-available-languages.get.groovy
+++ b/src/main/webapp/default-site/scripts/rest/api/1/server/get-available-languages.get.groovy
@@ -8,5 +8,7 @@ def result = []
 	result[2] = [:]
 	result[2].id = "kr"
 	result[2].label = "한국어"
-
+	result[3] = [:]
+	result[3].id = "de"
+	result[3].label = "Deutsch"
 return result


### PR DESCRIPTION
depends on https://github.com/craftercms/studio-ui/pull/1033 (Add resource bundles for german language)