### PR TITLE
Removed studio.preview.engineUrl property

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
@@ -206,7 +206,6 @@ public interface StudioConfiguration {
     String PREVIEW_DISABLE_DEPLOY_CRON = "studio.preview.disableDeployCron";
     String PREVIEW_TEMPLATE_NAME = "studio.preview.templateName";
     String PREVIEW_REPO_URL = "studio.preview.repoUrl";
-    String PREVIEW_ENGINE_URL = "studio.preview.engineUrl";
 
     /** Authoring Deployer **/
     String AUTHORING_TEMPLATE_NAME = "studio.authoring.templateName";

--- a/src/main/java/org/craftercms/studio/impl/v1/deployment/PreviewDeployerImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/deployment/PreviewDeployerImpl.java
@@ -50,7 +50,6 @@ import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_DEFA
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_DEFAULT_DELETE_TARGET_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_DEFAULT_PREVIEW_DEPLOYER_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_DISABLE_DEPLOY_CRON;
-import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_ENGINE_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_REPLACE;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_REPO_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_TEMPLATE_NAME;
@@ -184,7 +183,6 @@ public class PreviewDeployerImpl implements PreviewDeployer {
         Path repoUrlPath = Paths.get(repoUrl);
         repoUrl = repoUrlPath.normalize().toAbsolutePath().toString();
         requestBody.setRepoUrl(repoUrl);
-        requestBody.setEngineUrl(studioConfiguration.getProperty(PREVIEW_ENGINE_URL));
         requestBody.setSearchEngine(searchEngine);
         return requestBody.toJson();
     }
@@ -303,14 +301,6 @@ public class PreviewDeployerImpl implements PreviewDeployer {
 
         public void setRepoUrl(String repoUrl) {
             this.repoUrl = repoUrl;
-        }
-
-        public String getEngineUrl() {
-            return engineUrl;
-        }
-
-        public void setEngineUrl(String engineUrl) {
-            this.engineUrl = engineUrl;
         }
 
         public String getSearchEngine() {

--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -144,7 +144,6 @@ import static org.craftercms.studio.api.v1.util.StudioConfiguration.CONFIGURATIO
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.CONFIGURATION_SITE_MUTLI_ENVIRONMENT_CONFIG_BASE_PATH;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.JOB_DEPLOY_CONTENT_TO_ENVIRONMENT_STATUS_MESSAGE_DEFAULT;
-import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_ENGINE_URL;
 
 /**
  * Note: consider renaming
@@ -1080,9 +1079,7 @@ public class SiteServiceImpl implements SiteService {
     }
 
     private String getDestroySitePreviewContextUrl(String site) {
-	    StringBuilder sb = new StringBuilder(studioConfiguration.getProperty(PREVIEW_ENGINE_URL));
-        sb.append(studioConfiguration.getProperty(CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL));
-        String url = sb.toString();
+        String url = studioConfiguration.getProperty(CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL);
         url = url.replaceAll(StudioConstants.CONFIG_SITENAME_VARIABLE, site);
         return url;
     }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterSyncJobImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterSyncJobImpl.java
@@ -56,7 +56,6 @@ import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARAT
 import static org.craftercms.studio.api.v1.constant.StudioConstants.SITE_UUID_FILENAME;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.CLUSTERING_NODE_REGISTRATION;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL;
-import static org.craftercms.studio.api.v1.util.StudioConfiguration.PREVIEW_ENGINE_URL;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.REPO_BASE_PATH;
 import static org.craftercms.studio.api.v1.util.StudioConfiguration.SITES_REPOS_PATH;
 import static org.craftercms.studio.api.v2.dal.QueryParameterNames.CLUSTER_LOCAL_ADDRESS;
@@ -212,9 +211,7 @@ public class StudioClusterSyncJobImpl implements StudioClusterSyncJob {
     }
 
     private String getDestroySitePreviewContextUrl(String site) {
-        StringBuilder sb = new StringBuilder(studioConfiguration.getProperty(PREVIEW_ENGINE_URL));
-        sb.append(studioConfiguration.getProperty(CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL));
-        String url = sb.toString();
+        String url = studioConfiguration.getProperty(CONFIGURATION_SITE_PREVIEW_DESTROY_CONTEXT_URL);
         url = url.replaceAll(StudioConstants.CONFIG_SITENAME_VARIABLE, site);
         return url;
     }

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -105,7 +105,7 @@ studio.configuration.site.dataSources.configBasePath: /config/studio/data-source
 # File name where data sources configuration is stored.
 studio.configuration.site.dataSources.configFileName: cmis-config.xml
 # Destroy site context url for preview engine
-studio.configuration.site.preview.destroy.context.url: /api/1/site/context/destroy.json?crafterSite={siteName}
+studio.configuration.site.preview.destroy.context.url: http://localhost:8080/api/1/site/context/destroy.json?crafterSite={siteName}
 # Location pattern where dependency resolver specific configuration for a site is stored
 studio.configuration.site.dependencyResolver.configBasePath: /config/studio/dependency
 # File name where dependency specific configuration is stored
@@ -331,8 +331,6 @@ studio.preview.createTargetUrl: http://localhost:9191/api/1/target/upsert
 studio.preview.deleteTargetUrl: http://localhost:9191/api/1/target/delete-if-exists/{siteEnv}/{siteName}
 # URL to the preview repository (aka Sandbox) where authors save work-in-progress
 studio.preview.repoUrl: ${sys:crafter.data.dir}/repos/sites/{siteName}/sandbox
-# URL to the preview Crafter Engine
-studio.preview.engineUrl: http://localhost:8080
 # Name of template to use with the deployer for preview
 studio.preview.templateName: local
 # Replace existing configuration if one exists?


### PR DESCRIPTION
Removed studio.preview.engineUrl property. Deployer will handle this property (easier for Docker development).

Ticket craftercms/craftercms#2809
