### PR TITLE
Remove 400 response from /audit as all parameters are optional

### DIFF
--- a/src/main/api/2/studio-api-2.yaml
+++ b/src/main/api/2/studio-api-2.yaml
@@ -1259,8 +1259,6 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/AuditLog'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Remove the 400 Response from /Audit since all parameters are optional and a bad request cannot be received. 

https://github.com/craftercms/craftercms/issues/2870