### PR TITLE
Add withEndpointConfiguration() option for S3Client

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/aws/s3/AwsS3ServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/aws/s3/AwsS3ServiceImpl.java
@@ -68,9 +68,9 @@ public class AwsS3ServiceImpl extends AbstractAwsService<S3Profile> implements A
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
             .withCredentials(profile.getCredentialsProvider());
             
-        if(StringUtils.isNotEmpty(profile.getEndpoint()) && StringUtils.isNotEmpty(profile.getRegion())){
-            builder.withEndpointConfiguration( new AmazonS3ClientBuilder.EndpointConfiguration(profile.getEndpoint(), profile.getRegion()));
-        } else if(StringUtils.isNotEmpty(profile.getRegion())) {
+        if (StringUtils.isNotEmpty(profile.getEndpoint()) && StringUtils.isNotEmpty(profile.getRegion())){
+            builder.withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(profile.getEndpoint(), profile.getRegion()));
+        } else if (StringUtils.isNotEmpty(profile.getRegion())) {
             builder.withRegion(profile.getRegion());
         }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/aws/s3/AwsS3ServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/aws/s3/AwsS3ServiceImpl.java
@@ -61,12 +61,19 @@ public class AwsS3ServiceImpl extends AbstractAwsService<S3Profile> implements A
         this.partSize = partSize;
     }
 
+    /** 
+    * Add withEndpointConfiguration() to direct requests to a S3 compatible storage service
+    */
     protected AmazonS3 getS3Client(S3Profile profile) {
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
             .withCredentials(profile.getCredentialsProvider());
-        if(StringUtils.isNotEmpty(profile.getRegion())) {
+            
+        if(StringUtils.isNotEmpty(profile.getEndpoint()) && StringUtils.isNotEmpty(profile.getRegion())){
+            builder.withEndpointConfiguration( new AmazonS3ClientBuilder.EndpointConfiguration(profile.getEndpoint(), profile.getRegion()));
+        } else if(StringUtils.isNotEmpty(profile.getRegion())) {
             builder.withRegion(profile.getRegion());
         }
+
         return builder.build();
     }
 


### PR DESCRIPTION
Goal: Allow user to add an optional <endpoint> field in their AWS S3 profile configuration so that one can upload files to a S3 compatible cloud storage service

AwsS3ServiceImpl.java: Check for endpoint and region, and if both are given, then we can use withEndpointConfiguration() to connect to a S3 compatible storage
