### PR TITLE
Fix "studio" being stripped from beginning of domain name and respect…

### DIFF
--- a/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
+++ b/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
@@ -35,8 +35,8 @@ class EnvironmentOverrides {
         result.environment = serverProperties["environment"]
 
         def contextPath = request.getContextPath()
-        result.authoringServer = request.getRequestURL().toString().replace(request.getPathInfo().toString(), "")
-                .replace(contextPath, "")
+        result.authoringServer = (request.getHeader("x-forwarded-proto") ?: request.getScheme()) +
+                "://" + request.getServerName()
         if (contextPath.startsWith("/")) {
             contextPath = contextPath.substring(1)
         }


### PR DESCRIPTION
… X-Forwarded-Proto header if behind proxy

### Ticket reference or full description of what's in the PR

Currently, if a domain is pointed to Crafter Studio with the same subdomain name as the `contextPath`, the `/studio` portion of the domain gets stripped out, resulting in a broken URL in the `overlayhook`.
For example, `http://studio.example.com` would become `http:/.example.com`.

Also, if Crafter is behind a reverse proxy which sets the `X-Forwarded-Proto` header, the protocol is now respected.