### PR TITLE
Add `searchEngine` field to blueprint descriptor

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/constant/StudioConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v1/constant/StudioConstants.java
@@ -190,7 +190,7 @@ package org.craftercms.studio.api.v1.constant;
     /**
      * Search Engines
      */
-    String SEARCH_ENGINE_ELASTIC_SEARCH = "ElasticSearch";
+    String SEARCH_ENGINE_ELASTIC_SEARCH = "Elasticsearch";
     String SEARCH_ENGINE_CRAFTER_SEARCH = "CrafterSearch";
 
     /* Map keys */

--- a/src/main/java/org/craftercms/studio/api/v2/dal/BlueprintDescriptor.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/BlueprintDescriptor.java
@@ -53,6 +53,7 @@ public class BlueprintDescriptor {
         private Build build;
         private License license;
         private List<CraftercmsVersionSupported> craftercmsVersionsSupported;
+        private String searchEngine;
 
         public String getId() {
             return id;
@@ -132,6 +133,14 @@ public class BlueprintDescriptor {
 
         public void setCraftercmsVersionsSupported(List<CraftercmsVersionSupported> craftercmsVersionsSupported) {
             this.craftercmsVersionsSupported = craftercmsVersionsSupported;
+        }
+
+        public String getSearchEngine() {
+            return searchEngine;
+        }
+
+        public void setSearchEngine(final String searchEngine) {
+            this.searchEngine = searchEngine;
         }
     }
 

--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS `site` (
   `publishing_status_message`       VARCHAR(2000) NULL,
   `last_verified_gitlog_commit_id`  VARCHAR(50)   NULL,
   `sandbox_branch`                  VARCHAR(255)  NOT NULL DEFAULT 'master',
-  `search_engine`                   VARCHAR(20)   NOT NULL DEFAULT 'ElasticSearch',
+  `search_engine`                   VARCHAR(20)   NOT NULL DEFAULT 'Elasticsearch',
   PRIMARY KEY (`id`),
   UNIQUE INDEX `id_unique` (`id` ASC),
   UNIQUE INDEX `site_uuid_site_id_unique` (`site_uuid` ASC, `site_id` ASC),

--- a/src/main/resources/crafter/studio/database/upgrade-3.1.0.19-to-3.1.0.20.sql
+++ b/src/main/resources/crafter/studio/database/upgrade-3.1.0.19-to-3.1.0.20.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `site` MODIFY COLUMN `search_engine` VARCHAR(20) NOT NULL DEFAULT 'Elasticsearch' ;
+
+UPDATE `site` SET `search_engine` = 'Elasticsearch' WHERE `search_engine` = 'ElasticSearch' ;
+
+UPDATE _meta SET version = '3.1.0.20' ;

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -239,6 +239,13 @@ pipelines:
           filename: upgrade-3.1.0.18-to-3.1.0.19.sql
           updateIntegrity: true
 
+    - currentVersion: 3.1.0.19
+      nextVersion: 3.1.0.20
+      operations:
+        - type: dbScriptUpgrader
+          filename: upgrade-3.1.0.19-to-3.1.0.20.sql
+          updateIntegrity: true
+
   # Pipeline to upgrade site repositories
   site:
     - currentVersion: 3.1.0

--- a/src/main/webapp/repo-bootstrap/global/blueprints/empty/craftercms-plugin.yaml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/empty/craftercms-plugin.yaml
@@ -36,3 +36,4 @@ blueprint:
     url: https://opensource.org/licenses/MIT
   craftercmsVersionsSupported:
     - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/webapp/repo-bootstrap/global/blueprints/headless_blog/craftercms-plugin.yaml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/headless_blog/craftercms-plugin.yaml
@@ -40,3 +40,4 @@ blueprint:
       url: https://opensource.org/licenses/MIT
   craftercmsVersionsSupported:
     - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/webapp/repo-bootstrap/global/blueprints/headless_store/craftercms-plugin.yaml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/headless_store/craftercms-plugin.yaml
@@ -44,3 +44,4 @@ blueprint:
     url: https://opensource.org/licenses/MIT
   craftercmsVersionsSupported:
     - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/craftercms-plugin.yaml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/website_editorial/craftercms-plugin.yaml
@@ -56,3 +56,4 @@ blueprint:
     url: https://opensource.org/licenses/MIT
   craftercmsVersionsSupported:
     - version: 3.1.0
+  searchEngine: Elasticsearch


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/2969

Also small refactor for `Elasticsearch` name that was missed