### PR TITLE
Refactored GlobalUpgradeRepoOperation:

### DIFF
--- a/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-menu-config.xml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-menu-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This file contains global menu configuration for Crafter Studio.
+	The global menu shows up as the first screen after a user logs in
+	and displays a list of tools for the user including the list of sites.
+
+    The structure of this file is:
+	<globalMenu>
+		<items>
+			<item>
+				<id />
+				<label />
+				<icon />
+				<permission />
+			</item>
+		</items>
+	</globalMenu>
+
+-->
+
+<globalMenu>
+    <items>
+        <item>
+            <id>home.globalMenu.sites</id>
+            <label>Sites</label>
+            <icon>fa-sitemap</icon>
+            <permission>*</permission>
+        </item>
+        <item>
+            <id>home.globalMenu.users</id>
+            <label>Users</label>
+            <icon>fa-user</icon>
+            <permission>create_users</permission>
+        </item>
+        <item>
+            <id>home.globalMenu.groups</id>
+            <label>Groups</label>
+            <icon>fa-users</icon>
+            <permission>create_groups</permission>
+        </item>
+    </items>
+</globalMenu>

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-permission-mappings-config.xml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-permission-mappings-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This file contains global permissions configuration for Crafter Studio. Permissions per site are managed
+    within Crafter Studio's UI.
+    The structure of this file is:
+    <permissions>
+        <site id="###GLOBAL###"> (global management)
+            <role name="">
+                <rule regex="/.*">
+                    <allowed-permissions>
+                        <permission>Read</permission>
+                        <permission>Write</permission>
+                        <permission>Delete</permission>
+                        <permission>Create Folder</permission>
+                         <permission>Publish</permission>
+                    </allowed-permissions>
+                </rule>
+            </role>
+        </site>
+    </permissions>
+    This binds a set of permissions to a role globally for the entire application.
+-->
+
+<permissions>
+    <role name="system_admin">
+        <rule regex="/.*">
+            <allowed-permissions>
+                <permission>Read</permission>
+                <permission>Write</permission>
+                <permission>Delete</permission>
+                <permission>Create Folder</permission>
+                <permission>Publish</permission>
+                <permission>create-site</permission>
+                <permission>read_groups</permission>
+                <permission>create_groups</permission>
+                <permission>update_groups</permission>
+                <permission>delete_groups</permission>
+                <permission>read_users</permission>
+                <permission>create_users</permission>
+                <permission>update_users</permission>
+                <permission>delete_users</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+</permissions>

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-role-mappings-config.xml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-role-mappings-config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+-->
+
+<role-mappings>
+    <groups>
+        <group name="system_admin">
+            <role>system_admin</role>
+        </group>
+    </groups>
+</role-mappings>

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/empty/craftercms-plugin.yaml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/empty/craftercms-plugin.yaml
@@ -1,0 +1,39 @@
+# This file describes a blueprint for use in Crafter Studio
+
+# The version of this type of this file
+descriptorVersion: 1
+
+# Describe the blueprint
+blueprint:
+  id: org.craftercms.blueprint.empty
+  name: Empty Blueprint
+  tags: blueprint,website
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  description: |
+    Simple empty blueprint
+  website:
+    name: Empty Blueprint
+    url: https://craftercms.org
+  media:
+    screenshots:
+      - screenshot:
+          title: Home Page
+          description: Screenshot of the homepage
+          url: /studio/static-assets/images/blueprints/empty/bp_empty.png
+    developer:
+      company:
+        name: Crafter Software
+        email: info@craftersoftware.com
+        url: https://craftersoftware.com/
+  build:
+    id: c3d2a5444e6a24b5e0481d6ba87901d0b02716c8
+    date: 2019-01-23T00:00:00Z
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  craftercmsVersionsSupported:
+    - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_blog/craftercms-plugin.yaml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_blog/craftercms-plugin.yaml
@@ -1,0 +1,43 @@
+# This file describes a blueprint for use in Crafter Studio
+
+# The version of this type of this file
+descriptorVersion: 1
+
+# Describe the blueprint
+blueprint:
+  id: org.craftercms.blueprint.headless_blog
+  name: Headless Blog Blueprint
+  tags: blueprint,website,headless,blog
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  description: |
+    Headless blog blueprint
+  website:
+    name: Headless Blog Blueprint
+    url: https://craftercms.org
+  media:
+    screenshots:
+      - screenshot:
+          title: Author
+          description: Screenshot of the author item
+          url: /studio/static-assets/images/blueprints/headless_blog/bp_blog_author.png
+      - screenshot:
+          title: Post
+          description: Screenshot of the post item
+          url: /studio/static-assets/images/blueprints/headless_blog/bp_blog_post.png
+    developer:
+      company:
+        name: Crafter Software
+        email: info@craftersoftware.com
+        url: https://craftersoftware.com/
+  build:
+    id: c3d2a5444e6a24b5e0481d6ba87901d0b02716c8
+    date: 2019-01-23T00:00:00Z
+  license:
+      name: MIT
+      url: https://opensource.org/licenses/MIT
+  craftercmsVersionsSupported:
+    - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_store/craftercms-plugin.yaml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_store/craftercms-plugin.yaml
@@ -1,0 +1,47 @@
+# This file describes a blueprint for use in Crafter Studio
+
+# The version of this type of this file
+descriptorVersion: 1
+
+# Describe the blueprint
+blueprint:
+  id: org.craftercms.blueprint.headless_store
+  name: Headless Store Blueprint
+  tags: blueprint,website,headless,graphql
+  version:
+    major: 1
+    minor: 1
+    patch: 0
+  description: |
+    GraphQL-based and headless blueprint for a storefront
+  website:
+    name: GraphQL Headless Store Blueprint
+    url: https://craftercms.org
+  media:
+    screenshots:
+      - screenshot:
+          title: Store Items
+          description: Screenshot of the store items
+          url: /studio/static-assets/images/blueprints/headless_store/bp_store_1.png
+      - screenshot:
+          title: Store Items
+          description: Screenshot of the store items
+          url: /studio/static-assets/images/blueprints/headless_store/bp_store_2.png
+      - screenshot:
+          title: Store Items
+          description: Screenshot of the store items
+          url: /studio/static-assets/images/blueprints/headless_store/bp_store_3.png
+    developer:
+      company:
+        name: Crafter Software
+        email: info@craftersoftware.com
+        url: https://craftersoftware.com/
+  build:
+    id: c3d2a5444e6a24b5e0481d6ba87901d0b02716c8
+    date: 2019-01-23T00:00:00Z
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  craftercmsVersionsSupported:
+    - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/website_editorial/craftercms-plugin.yaml
+++ b/src/main/resources/crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/website_editorial/craftercms-plugin.yaml
@@ -1,0 +1,59 @@
+# This file describes a blueprint for use in Crafter Studio
+
+# The version of this type of this file
+descriptorVersion: 1
+
+# Describe the blueprint
+blueprint:
+  id: org.craftercms.blueprint.editorial
+  name: Website Editorial Blueprint
+  tags: blueprint,website,editorial
+  version:
+    major: 1
+    minor: 0
+    patch: 0
+  description: |
+    Editorial blueprint
+  website:
+    name: Website Editorial Blueprint
+    url: https://craftercms.org
+  media:
+    screenshots:
+      - screenshot:
+          title: Home Page
+          description: Screenshot of the home page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_home.png
+      - screenshot:
+          title: Style Page
+          description: Screenshot of the style page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_style.png
+      - screenshot:
+          title: Health Page
+          description: Screenshot of the health page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_health.png
+      - screenshot:
+          title: Entertainment Page
+          description: Screenshot of the entertainment page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_entertainment.png
+      - screenshot:
+          title: Technology Page
+          description: Screenshot of the technology page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_technology.png
+      - screenshot:
+          title: Article Page
+          description: Screenshot of the article page
+          url: /studio/static-assets/images/blueprints/website_editorial/bp_editorial_article.png
+    developer:
+      company:
+        name: Crafter Software
+        email: info@craftersoftware.com
+        url: https://craftersoftware.com/
+  build:
+    id: c3d2a5444e6a24b5e0481d6ba87901d0b02716c8
+    date: 2019-01-23T00:00:00Z
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  craftercmsVersionsSupported:
+    - version: 3.1.0
+  searchEngine: Elasticsearch

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -93,9 +93,9 @@ pipelines:
           filename: upgrade-3.1.0-to-3.1.0.1.sql
         - type: globalRepoUpgrader
           files:
-            - configuration/global-menu-config.xml
-            - configuration/global-permission-mappings-config.xml
-            - configuration/global-role-mappings-config.xml
+            - crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-menu-config.xml:configuration/global-menu-config.xml
+            - crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-permission-mappings-config.xml:configuration/global-permission-mappings-config.xml
+            - crafter/studio/upgrade/3.1.0.1/repo-bootstrap/global/configuration/global-role-mappings-config.xml:configuration/global-role-mappings-config.xml
 
     - currentVersion: 3.1.0.1
       nextVersion: 3.1.0.2
@@ -203,10 +203,10 @@ pipelines:
           updateIntegrity: true
         - type: globalRepoUpgrader
           files:
-            - blueprints/empty/craftercms-plugin.yaml
-            - blueprints/headless_blog/craftercms-plugin.yaml
-            - blueprints/headless_store/craftercms-plugin.yaml
-            - blueprints/website_editorial/craftercms-plugin.yaml
+            - crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/empty/craftercms-plugin.yaml:blueprints/empty/craftercms-plugin.yaml
+            - crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_blog/craftercms-plugin.yaml:blueprints/headless_blog/craftercms-plugin.yaml
+            - crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/headless_store/craftercms-plugin.yaml:blueprints/headless_store/craftercms-plugin.yaml
+            - crafter/studio/upgrade/3.1.0.15/repo-bootstrap/global/blueprints/website_editorial/craftercms-plugin.yaml:blueprints/website_editorial/craftercms-plugin.yaml
 
     - currentVersion: 3.1.0.15
       nextVersion: 3.1.0.16


### PR DESCRIPTION
* `GlobalUpgradeRepoOperation` now copies the files from specific version paths instead of the current repo-bootstrap. That way, if something changes in the repo-boostrap (like the blueprint folders), the pipeline won't fail.

Ticket craftercms/craftercms#3068
