### PR TITLE
Add configurable default search engine:

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v1/util/StudioConfiguration.java
@@ -214,6 +214,7 @@ public interface StudioConfiguration {
     /** Preview Search **/
     String PREVIEW_SEARCH_CREATE_URL = "studio.preview.search.createUrl";
     String PREVIEW_SEARCH_DELETE_URL = "studio.preview.search.deleteUrl";
+    String PREVIEW_SEARCH_ENGINE = "studio.preview.search.engine";
 
     /** Publishing Manager */
     String PUBLISHING_MANAGER_INDEX_FILE = "studio.publishingManager.indexFile";

--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -51,7 +51,6 @@ import org.craftercms.commons.entitlements.exception.EntitlementException;
 import org.craftercms.commons.entitlements.model.EntitlementType;
 import org.craftercms.commons.entitlements.validator.EntitlementValidator;
 import org.craftercms.commons.plugin.model.PluginDescriptor;
-import org.craftercms.commons.plugin.model.SearchEngines;
 import org.craftercms.commons.validation.annotations.param.ValidateIntegerParam;
 import org.craftercms.commons.validation.annotations.param.ValidateNoTagsParam;
 import org.craftercms.commons.validation.annotations.param.ValidateParams;
@@ -751,16 +750,16 @@ public class SiteServiceImpl implements SiteService {
         }
 
         // try to get the search engine from the blueprint descriptor file
-        String searchEngine = SearchEngines.ELASTICSEARCH;
+        String searchEngine = studioConfiguration.getProperty(StudioConfiguration.PREVIEW_SEARCH_ENGINE);
 
         if (Objects.nonNull(descriptor) && Objects.nonNull(descriptor.getPlugin())) {
             searchEngine = descriptor.getPlugin().getSearchEngine();
-            logger.info("Using searchEngine {0} from plugin descriptor", searchEngine);
+            logger.info("Using search engine {0} from plugin descriptor", searchEngine);
         } else if (Objects.nonNull(descriptor) && Objects.nonNull(descriptor.getBlueprint())) {
             searchEngine = descriptor.getBlueprint().getSearchEngine();
-            logger.info("Using searchEngine {0} from blueprint descriptor", searchEngine);
+            logger.info("Using search engine {0} from blueprint descriptor", searchEngine);
         } else {
-            logger.info("Missing descriptor, using default searchEngine {0}", searchEngine);
+            logger.info("Missing descriptor, using default search engine {0}", searchEngine);
         }
 
         if (success) {

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/plugin/AbstractPluginDescriptorUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/plugin/AbstractPluginDescriptorUpgradeOperation.java
@@ -69,7 +69,8 @@ public abstract class AbstractPluginDescriptorUpgradeOperation extends AbstractU
     public void execute(final String site) throws UpgradeException {
         Path descriptorFile = getRepositoryPath(site).getParent().resolve(descriptorPath);
         if (Files.notExists(descriptorFile)) {
-            throw new UpgradeException("Plugin descriptor file not found for site " + site);
+            logger.info("Plugin descriptor file not found for site {0}", site);
+            return;
         }
         try (Reader reader = Files.newBufferedReader(descriptorFile)) {
             PluginDescriptor descriptor = descriptorReader.read(reader);

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -348,7 +348,7 @@ studio.authoring.templateName: authoring
 ############################################################
 ##                   Preview Search                       ##
 ############################################################
-# The default search engine to use when creating targets for preview
+# The default search engine to use when creating targets for preview and nothing is indicated in the blueprint
 studio.preview.search.engine: CrafterSearch
 studio.preview.search.createUrl: http://localhost:8080/crafter-search/api/2/admin/index/create
 studio.preview.search.deleteUrl: http://localhost:8080/crafter-search/api/2/admin/index/delete/{siteName}

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -348,6 +348,8 @@ studio.authoring.templateName: authoring
 ############################################################
 ##                   Preview Search                       ##
 ############################################################
+# The default search engine to use when creating targets for preview
+studio.preview.search.engine: CrafterSearch
 studio.preview.search.createUrl: http://localhost:8080/crafter-search/api/2/admin/index/create
 studio.preview.search.deleteUrl: http://localhost:8080/crafter-search/api/2/admin/index/delete/{siteName}
 


### PR DESCRIPTION
- Defaults to CrafterSearch to support remote repositories from 3.0.x sites

https://github.com/craftercms/craftercms/issues/3210
