### PR TITLE
Fix #3280: User API - usernames with dots are truncated

### DIFF
--- a/src/main/resources/crafter/studio/extension/rendering-overlay-context.xml
+++ b/src/main/resources/crafter/studio/extension/rendering-overlay-context.xml
@@ -36,6 +36,10 @@
         <entry key="/*" value-ref="crafter.pageRenderController"/>
     </util:map>
 
+    <mvc:annotation-driven>
+        <mvc:path-matching registered-suffixes-only="true" />
+    </mvc:annotation-driven>
+
     <!-- ////////////////////////////////////// -->
     <!--      Controllers                       -->
     <!-- ////////////////////////////////////// -->


### PR DESCRIPTION
Fix https://github.com/craftercms/craftercms/issues/3280: User API - usernames with dots are truncated

Add a regexp in mapping pattern for /api/2/users/{id}

See https://github.com/spring-projects/spring-framework/issues/10832 or https://github.com/spring-projects/spring-framework/issues/12288

