### PR TITLE
Add crafterCmsEditions to blog bp plugin

### DIFF
--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/craftercms-plugin.yaml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/craftercms-plugin.yaml
@@ -45,4 +45,7 @@ plugin:
     - major: 3
       minor: 1
       patch: 1
+  crafterCmsEditions:
+    - community
+    - enterprise
   searchEngine: Elasticsearch


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
I notice that the `api/2/sites/available_blueprints.json` was returning `null`  for the `crafterCmsEditions` property in the blog blueprint.
 
I talked with @jdrossl and he said this value should not affect if is present or not. 

I'm adding it to the blog blueprint descriptor, since we have it for everyone else except for this one.