### PR TITLE
[3665] [studio] Remove space between `COUNT` and `(` in SQL

### DIFF
--- a/src/main/resources/org/craftercms/studio/api/v2/dal/AuditDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/AuditDAO.xml
@@ -151,7 +151,7 @@
     </select>
 
     <select id="getAuditLogTotal" parameterType="java.util.Map" resultType="int">
-        SELECT count (1)
+        SELECT count(1)
         FROM audit a INNER JOIN site s on a.site_id = s.id
         WHERE 1 = 1
         <if test="siteId != null and siteId !=  '' ">

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/GroupDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/GroupDAO.xml
@@ -177,7 +177,7 @@
     </delete>
 
     <select id="groupExists" resultType="Integer" parameterType="java.util.Map">
-        SELECT COUNT (1) FROM `group` WHERE id = #{groupId} OR group_name = #{groupName}
+        SELECT COUNT(1) FROM `group` WHERE id = #{groupId} OR group_name = #{groupName}
     </select>
 
     <select id="getGroupByName" parameterType="java.util.Map" resultMap="GroupMap">

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/SecurityDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/SecurityDAO.xml
@@ -313,7 +313,7 @@
     </update>
 
     <select id="userExistsInGroup" resultType="Integer" parameterType="java.util.Map">
-            SELECT COUNT (1)
+            SELECT COUNT(1)
             FROM `group` cg
             INNER JOIN group_user cug ON cg.id = cug.group_id
             INNER JOIN `user` cu ON cug.user_id = cu.id
@@ -322,13 +322,13 @@
     </select>
 
     <select id="userExists" resultType="Integer" parameterType="java.util.Map">
-            SELECT COUNT (1)
+            SELECT COUNT(1)
             FROM `user` cu
             WHERE cu.username = #{username}
     </select>
 
     <select id="groupExists" resultType="Integer" parameterType="java.util.Map">
-            SELECT COUNT (1)
+            SELECT COUNT(1)
             FROM `group` cg
             WHERE  cg.group_name = #{groupName}
     </select>

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/UserDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/UserDAO.xml
@@ -152,13 +152,13 @@
     </update>
 
     <select id="userExists" resultType="Integer" parameterType="java.util.Map">
-            SELECT COUNT (1)
+            SELECT COUNT(1)
             FROM `user`
             WHERE id = #{userId} OR username = #{username}
     </select>
 
     <select id="isUserMemberOfGroup" resultType="Integer" parameterType="java.util.Map">
-            SELECT COUNT (1)
+            SELECT COUNT(1)
             FROM ((`user` cu INNER JOIN `group_user` gu ON gu.user_id = cu.id)
               INNER JOIN `group` g ON gu.group_id = g.id)
             WHERE cu.username = #{username}


### PR DESCRIPTION
Fixed typo in SQL statements using count function

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3665