### PR TITLE
Rolling back change of pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,8 @@
                         </configuration>
                     </execution>
 
+                    <!--
+                    To be enabled when studio-ui 2019 branch becomes develop.
                     <execution>
                         <id>install legacy hybrid deps</id>
                         <goals>
@@ -677,6 +679,7 @@
                         </configuration>
                     </execution>
                 </executions>
+                -->
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Rolling back change of pom that is not releaseable until studio-ui 2019 becomes develop
