### PR TITLE
[3708] [studio]Site creation rollback when a site is created from git remote empty repo doesn't remove sandbox folder

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -767,6 +767,7 @@ public class SiteServiceImpl implements SiteService {
         }
 
         if (!success) {
+            contentRepository.removeRemoteRepositoriesForSite(siteId);
             contentRepository.deleteSite(siteId);
             throw new ServiceLayerException("Failed to create site: " + siteId + " ID: " + siteId + " as clone from " +
                     "remote repository: " + remoteName + " (" + remoteUrl + ")");


### PR DESCRIPTION
Fixed rollback remote repository in db

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3708
