### PR TITLE
[3766] [studio-ui] Parameter "token" missing from call to /api/1/monitoring/log.json

### DIFF
--- a/src/main/java/org/craftercms/studio/controller/rest/v2/ProxyController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/ProxyController.java
@@ -82,10 +82,10 @@ public class ProxyController {
         }
 
         // Execute proxied request and return response
-        HttpEntity<String> httpEntity = new HttpEntity<>(body, headers);
+        HttpEntity httpEntity = new HttpEntity(body, headers);
         RestTemplate restTemplate = new RestTemplate();
         try {
-            return restTemplate.exchange(uri, method, httpEntity, String.class);
+            return restTemplate.exchange(uri, method, httpEntity, Object.class);
         } catch(HttpStatusCodeException e) {
             return ResponseEntity.status(e.getRawStatusCode())
                     .headers(e.getResponseHeaders())


### PR DESCRIPTION
Fixed wrong response formatting

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3766