### PR TITLE
modify order of getAllPublishedEnvironments

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DeploymentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DeploymentServiceImpl.java
@@ -77,6 +77,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -761,9 +762,9 @@ public class DeploymentServiceImpl implements DeploymentService {
     }
 
     protected Set<String> getAllPublishedEnvironments(String site) {
-        Set<String> publishedEnvironments = new HashSet<String>();
-        publishedEnvironments.add(servicesConfig.getLiveEnvironment(site));
+        Set<String> publishedEnvironments = new LinkedHashSet<String>();
         publishedEnvironments.add(servicesConfig.getStagingEnvironment(site));
+        publishedEnvironments.add(servicesConfig.getLiveEnvironment(site));
         return publishedEnvironments;
     }
 


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
When we have both staging and live, the default order of environment list should be `staging` -> `live`.
`HashSet` cannot guarantee this. `LinkedHashSet` guarantee adding order.