### PR TITLE
Fix profileId and siteId parameter type in s3 and webdav list.

### DIFF
--- a/src/main/api/2/studio-api-2.yaml
+++ b/src/main/api/2/studio-api-2.yaml
@@ -1194,15 +1194,13 @@ paths:
           description: The site ID
           required: true
           schema:
-            type: integer
-            format: int64
+            type: string
         - name: profileId
           in: query
           description: The profile ID
           required: true
           schema:
-            type: integer
-            format: int64
+            type: string
         - name: path
           in: query
           description: The path of the directory to list (defaults to the root)
@@ -1350,15 +1348,13 @@ paths:
           description: The site ID
           required: true
           schema:
-            type: integer
-            format: int64
+            type: string
         - name: profileId
           in: query
           description: The profile ID
           required: true
           schema:
-            type: integer
-            format: int64
+            type: string
         - name: path
           in: query
           description: The path of the directory to list (defaults to the root)


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Fix  the `siteId` and `profileId` parameter type from int to string in `/aws/s3/list` and `/webdav/list`
