### PR TITLE
[3979] [studio] api/2/configuration/get_configuration_history doesn't work when default environment is set

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
@@ -329,6 +329,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                             .replaceAll(PATTERN_MODULE, module)
                             .replaceAll(PATTERN_ENVIRONMENT, environment);
             configPath = Paths.get(configBasePath, path).toString();
+            if (!contentService.contentExists(siteId, configPath)) {
+                configBasePath = studioConfiguration.getProperty(CONFIGURATION_SITE_CONFIG_BASE_PATH_PATTERN)
+                        .replaceAll(PATTERN_MODULE, module);
+                configPath = Paths.get(configBasePath, path).toString();
+            }
         } else {
             String configBasePath = studioConfiguration.getProperty(CONFIGURATION_SITE_CONFIG_BASE_PATH_PATTERN)
                     .replaceAll(PATTERN_MODULE, module);


### PR DESCRIPTION
Fixed configuration history not defaulting to base configuration

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/3979