### PR TITLE
[studio] EnvironmentOverrides updates

### DIFF
--- a/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
+++ b/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
@@ -16,95 +16,108 @@
 
 package scripts.libs
 
-import scripts.api.SiteServices;
+import org.craftercms.studio.api.v1.log.LoggerFactory
 import scripts.api.SecurityServices
+import scripts.api.SiteServices
 
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.SECURITY_PASSWORD_REQUIREMENTS_VALIDATION_REGEX;
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.SECURITY_TYPE;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.SECURITY_PASSWORD_REQUIREMENTS_VALIDATION_REGEX
 
 class EnvironmentOverrides {
-    static SITE_SERVICES_BEAN = "cstudioSiteServiceSimple"
-    static USER_SERVICES_BEAN = "userService"
+  static SITE_SERVICES_BEAN = "cstudioSiteServiceSimple"
+  static USER_SERVICES_BEAN = "userService"
+  static logger = LoggerFactory.getLogger(ExtractMetadataApi.class)
 
-    static getValuesForSite(appContext, request, response) {
+  static getValuesForSite(appContext, request, response) {
 
-        def result = [:]
-        def serverProperties = appContext.get("studio.crafter.properties")
-        def cookies = request.getCookies();
+    def result = [:]
+    def serverProperties = appContext.get("studio.crafter.properties")
+    def cookies = request.getCookies()
 
-        def context = SiteServices.createContext(appContext, request)
-        result.environment = serverProperties["environment"]
+    def context = SiteServices.createContext(appContext, request)
+    result.environment = serverProperties["environment"]
 
-        def contextPath = request.getContextPath()
-        if (contextPath.startsWith("/")) {
-            contextPath = contextPath.substring(1)
-        }
-        result.studioContext = contextPath
-
-        try {
-            def siteServiceSB = context.applicationContext.get(SITE_SERVICES_BEAN)
-            def userServiceSB = context.applicationContext.get(USER_SERVICES_BEAN)
-            result.site = Cookies.getCookieValue("crafterSite", request)
-            result.authoringServer =  siteServiceSB.getAuthoringServerUrl(result.site)
-            result.previewServerUrl = siteServiceSB.getPreviewServerUrl(result.site)
-            result.previewEngineServerUrl = siteServiceSB.getPreviewEngineServerUrl(result.site)
-            result.graphqlServerUrl = siteServiceSB.getGraphqlServerUrl(result.site)
-
-            result.user = SecurityServices.getCurrentUser(context)
-
-            def studioConfigurationSB = context.applicationContext.get("studioConfiguration")
-            try {
-                def authenticatedUser = userServiceSB.getCurrentUser()
-                result.authenticationType = authenticatedUser.getAuthenticationType()
-            } catch (error) {
-                result.authenticationType = ""
-            }
-
-            result.passwordRequirementsRegex = studioConfigurationSB.getProperty(SECURITY_PASSWORD_REQUIREMENTS_VALIDATION_REGEX)
-
-            def language = Cookies.getCookieValue("crafterStudioLanguage", request)
-            if(language == null || language == "" || language == "UNSET") {
-                language = "en"
-            }
-            result.language = language
-
-            if(result.user == null){
-                response.sendRedirect("/studio/login")
-            }else{
-                try{
-                    def roles = SecurityServices.getUserRoles(context, result.site, result.user)
-
-                    if(roles!=null && roles.size() > 0) {
-                        if (roles.contains("admin")) {
-                            result.role = "admin"
-                        } else {
-                            result.role = roles[0]
-                        }
-                    }
-                    else {
-                        response.sendRedirect("/studio/#/sites?siteValidation="+result.site)
-                    }
-                }catch(error){
-                    response.sendRedirect("/studio/#/sites?siteValidation="+result.site)
-                }
-                def sites = SiteServices.getSitesPerUser(context, result.user, 0, 25)
-
-                result.siteTitle = result.site +sites.size;
-
-                for(int j = 0; j < sites.size; j++) {
-                    def site = sites[j];
-                    if(site.siteId == result.site) {
-                        result.siteTitle = site.name;
-                        break;
-                    }
-                }
-            }
-        }
-        catch(err) {
-            result.err = err
-            throw new Exception(err)
-        }
-
-        return result;
+    def contextPath = request.getContextPath()
+    if (contextPath.startsWith("/")) {
+      contextPath = contextPath.substring(1)
     }
+    result.studioContext = contextPath
+
+    try {
+      def siteServiceSB = context.applicationContext.get(SITE_SERVICES_BEAN)
+      def userServiceSB = context.applicationContext.get(USER_SERVICES_BEAN)
+      result.site = Cookies.getCookieValue("crafterSite", request)
+      result.authoringServer = siteServiceSB.getAuthoringServerUrl(result.site)
+      result.previewServerUrl = siteServiceSB.getPreviewServerUrl(result.site)
+      result.previewEngineServerUrl = siteServiceSB.getPreviewEngineServerUrl(result.site)
+      result.graphqlServerUrl = siteServiceSB.getGraphqlServerUrl(result.site)
+
+      result.user = SecurityServices.getCurrentUser(context)
+
+      def studioConfigurationSB = context.applicationContext.get("studioConfiguration")
+      try {
+        def authenticatedUser = userServiceSB.getCurrentUser()
+        result.authenticationType = authenticatedUser.getAuthenticationType()
+      } catch (error) {
+        result.authenticationType = ""
+      }
+
+      result.passwordRequirementsRegex = studioConfigurationSB.getProperty(SECURITY_PASSWORD_REQUIREMENTS_VALIDATION_REGEX)
+
+      def language = Cookies.getCookieValue("crafterStudioLanguage", request)
+      if (language == null || language == "" || language == "UNSET") {
+        language = "en"
+      }
+
+      result.language = language
+
+      if (result.user == null) {
+        response.sendRedirect("/studio/login")
+      } else {
+        def sites = SiteServices.getSitesPerUser(context, result.user, 0, 25)
+        if (sites.isEmpty()) {
+          response.sendRedirect("/studio/?noSites")
+        } else {
+
+          if (result.site == "UNSET") {
+            result.site = sites[0].siteId
+            Cookies.createCookie("crafterSite", sites[0].siteId, request.getServerName(), "/", response)
+          }
+
+          try {
+            def roles = SecurityServices.getUserRoles(context, result.site, result.user)
+            if (roles != null && roles.size() > 0) {
+              if (roles.contains("admin")) {
+                result.role = "admin"
+              } else {
+                result.role = roles[0]
+              }
+            } else {
+              logger.info("[EnvironmentOverrides] Attempt to visit '${result.site}' site without the necessary roles")
+              response.sendRedirect("/studio/?roles")
+            }
+          } catch (error) {
+            logger.info("[EnvironmentOverrides] Error retrieving roles for site '${result.site}'")
+            response.sendRedirect("/studio/?error")
+          }
+
+          result.siteTitle = result.site + sites.size;
+
+          for (int j = 0; j < sites.size; j++) {
+            def site = sites[j]
+            if (site.siteId == result.site) {
+              result.siteTitle = site.name
+              result.activeSite = site
+              break;
+            }
+          }
+
+        }
+      }
+    } catch (err) {
+      result.err = err
+      throw new Exception(err)
+    }
+
+    return result;
+  }
 }

--- a/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
+++ b/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
@@ -23,7 +23,6 @@ import scripts.api.SiteServices
 import static org.craftercms.studio.api.v2.utils.StudioConfiguration.SECURITY_PASSWORD_REQUIREMENTS_VALIDATION_REGEX
 
 class EnvironmentOverrides {
-  static SITE_SERVICES_BEAN = "cstudioSiteServiceSimple"
   static USER_SERVICES_BEAN = "userService"
   static logger = LoggerFactory.getLogger(ExtractMetadataApi.class)
 
@@ -31,7 +30,6 @@ class EnvironmentOverrides {
 
     def result = [:]
     def serverProperties = appContext.get("studio.crafter.properties")
-    def cookies = request.getCookies()
 
     def context = SiteServices.createContext(appContext, request)
     result.environment = serverProperties["environment"]
@@ -43,14 +41,8 @@ class EnvironmentOverrides {
     result.studioContext = contextPath
 
     try {
-      def siteServiceSB = context.applicationContext.get(SITE_SERVICES_BEAN)
       def userServiceSB = context.applicationContext.get(USER_SERVICES_BEAN)
       result.site = Cookies.getCookieValue("crafterSite", request)
-      result.authoringServer = siteServiceSB.getAuthoringServerUrl(result.site)
-      result.previewServerUrl = siteServiceSB.getPreviewServerUrl(result.site)
-      result.previewEngineServerUrl = siteServiceSB.getPreviewEngineServerUrl(result.site)
-      result.graphqlServerUrl = siteServiceSB.getGraphqlServerUrl(result.site)
-
       result.user = SecurityServices.getCurrentUser(context)
 
       def studioConfigurationSB = context.applicationContext.get("studioConfiguration")


### PR DESCRIPTION
Removes the no-site-set redirect 
Removes service invocations that tried to read things from environment-config.xml, which is now removed by upgrade manager

https://github.com/craftercms/craftercms/issues/3982
https://github.com/craftercms/craftercms/issues/3889

For more comfortable/easier review of the files tab, [click here](https://github.com/craftercms/studio/pull/1967/files?diff=unified&w=1)