### PR TITLE
[4158] [studio] The bulk publisher should skip DB item_metadata entries with commit_id = null

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
@@ -1182,6 +1183,10 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
                     for (DeploymentItemTO deploymentItem : deploymentItems) {
                         commitId = deploymentItem.getCommitId();
                         path = helper.getGitPath(deploymentItem.getPath());
+                        if (Objects.isNull(commitId)) {
+                            logger.warn("Skipping file " + path + " because commit id is null");
+                            continue;
+                        }
                         logger.debug("Checking out file " + path + " from commit id " + commitId +
                                 " for site " + site);
 


### PR DESCRIPTION
Skipping files with commit id null when publishing

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4158