### PR TITLE
Add ElasticSearch direct query

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/search/internal/SearchServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/search/internal/SearchServiceInternalImpl.java
@@ -434,6 +434,21 @@ public class SearchServiceInternalImpl implements SearchServiceInternal {
             query.must(keywordsQuery);
         }
 
+        String esQueries = params.getEsQueries();
+        if (StringUtils.isNotEmpty(esQueries)) {
+            String[] keywords = esQueries.split(",");
+            if (ArrayUtils.isNotEmpty(keywords)) {
+                for (String keyword : keywords) {
+                    String[] queries = keyword.split(":");
+                    if (ArrayUtils.isNotEmpty(queries) && queries.length == 3) {
+                        if (queries[0].equals("regexp")) {
+                            query.must(QueryBuilders.regexpQuery(queries[1], queries[2]));
+                        }
+                    }
+                }
+            }
+        }
+
         if (StringUtils.isNotEmpty(params.getPath())) {
             query.filter(QueryBuilders.regexpQuery(pathFieldName, params.getPath()));
         }

--- a/src/main/java/org/craftercms/studio/model/search/SearchParams.java
+++ b/src/main/java/org/craftercms/studio/model/search/SearchParams.java
@@ -30,6 +30,12 @@ public class SearchParams {
     protected String keywords;
 
     /**
+     * ElasticSearch Query to search in the files.
+     * (Ex) `regexp:localId:/static-assets/.*`
+     */
+    protected String esQueries;
+
+    /**
      * Lucene query to execute.
      */
     protected String query;
@@ -70,6 +76,14 @@ public class SearchParams {
 
     public void setKeywords(final String keywords) {
         this.keywords = keywords;
+    }
+
+    public String getEsQueries() {
+        return esQueries;
+    }
+
+    public void setEsQueries() {
+        this.esQueries = esQueries;
     }
 
     public String getQuery() {


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
Add an option to search with Elastic Search query:

Sample of query:

```
regexp:localId:/static-assets/.*,match:localId:lastEditedBy:admin
```

### Reason
Search API should have a method to directly query ElasticSearch.
Above I'm using `,` to separate each query and `:` to separate among operator, param and value.

If this solution does not fit, will it possible to discuss a similar solution?
In my case, I want to search with query such as:

```
{
    "query" : {
    	"bool": {
    		"must": [
    			{ 
    				"regexp": {
    					"localId": {
                			"value": "/static-assets/.*viber.*",
                			"flags" : "ALL",
                			"max_determinized_states": 10000,
                			"rewrite": "constant_score"
    					}
    				}
            	},
    			{ "match" : { "lastEditedBy": "admin" } }
    		]	
    	}
    }
}
```