### PR TITLE
[4180] [studio] In a Studio cluster, when saving a configuration file, just one of the nodes has the site context rebuilt

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterSyncJobImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterSyncJobImpl.java
@@ -33,6 +33,7 @@ import org.craftercms.studio.api.v1.log.LoggerFactory;
 import org.craftercms.studio.api.v1.repository.ContentRepository;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v1.service.deployment.DeploymentService;
+import org.craftercms.studio.api.v1.service.event.EventService;
 import org.craftercms.studio.api.v1.service.site.SiteService;
 import org.craftercms.studio.api.v2.dal.ClusterDAO;
 import org.craftercms.studio.api.v2.dal.ClusterMember;
@@ -75,6 +76,7 @@ public class StudioClusterSyncJobImpl implements StudioClusterSyncJob {
     private ServicesConfig servicesConfig;
     private GitRepositories repositoryType;
     private DeploymentService deploymentService;
+    private EventService eventService;
 
     private ReentrantLock singleWorkerLock = new ReentrantLock();
     private final static Map<String, String> deletedSitesMap = new HashMap<String, String>();
@@ -139,6 +141,7 @@ public class StudioClusterSyncJobImpl implements StudioClusterSyncJob {
                                                 nodeSandobxSyncTask.setServicesConfig(servicesConfig);
                                                 nodeSandobxSyncTask.setClusterNodes(clusterMembers);
                                                 nodeSandobxSyncTask.setDeploymentService(deploymentService);
+                                                nodeSandobxSyncTask.setEventService(eventService);
                                                 taskExecutor.execute(nodeSandobxSyncTask);
                                                 break;
                                             case PUBLISHED:
@@ -313,5 +316,13 @@ public class StudioClusterSyncJobImpl implements StudioClusterSyncJob {
 
     public void setDeploymentService(DeploymentService deploymentService) {
         this.deploymentService = deploymentService;
+    }
+
+    public EventService getEventService() {
+        return eventService;
+    }
+
+    public void setEventService(EventService eventService) {
+        this.eventService = eventService;
     }
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioNodeSyncBaseTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioNodeSyncBaseTask.java
@@ -42,6 +42,7 @@ import org.craftercms.commons.crypto.CryptoException;
 import org.craftercms.commons.crypto.TextEncryptor;
 import org.craftercms.commons.crypto.impl.PbkAesTextEncryptor;
 import org.craftercms.studio.api.v1.constant.GitRepositories;
+import org.craftercms.studio.api.v1.service.event.EventService;
 import org.craftercms.studio.api.v2.dal.RemoteRepository;
 import org.craftercms.studio.api.v1.dal.SiteFeed;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
@@ -86,6 +87,7 @@ public abstract class StudioNodeSyncBaseTask implements Runnable {
     protected ServicesConfig servicesConfig;
     protected SiteService siteService;
     protected DeploymentService deploymentService;
+    protected EventService eventService;
 
 	// Abstract methods to be implemented by Sandbox/Published classes
 	protected abstract boolean isSyncRequiredInternal(String siteId, String siteDatabaseLastCommitId);
@@ -481,5 +483,13 @@ public abstract class StudioNodeSyncBaseTask implements Runnable {
 
     public void setDeploymentService(DeploymentService deploymentService) {
         this.deploymentService = deploymentService;
+    }
+
+    public EventService getEventService() {
+        return eventService;
+    }
+
+    public void setEventService(EventService eventService) {
+        this.eventService = eventService;
     }
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioNodeSyncSandboxTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioNodeSyncSandboxTask.java
@@ -16,9 +16,8 @@
 
 package org.craftercms.studio.impl.v2.service.cluster;
 
-import static org.craftercms.studio.api.v1.constant.GitRepositories.PUBLISHED;
 import static org.craftercms.studio.api.v1.constant.GitRepositories.SANDBOX;
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.PUBLISHED_PATH;
+import static org.craftercms.studio.api.v1.ebus.EBusConstants.EVENT_PREVIEW_SYNC;
 import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_BASE_PATH;
 import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_SANDBOX_BRANCH;
 import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_SYNC_DB_COMMIT_MESSAGE_NO_PROCESSING;
@@ -46,6 +45,7 @@ import org.craftercms.commons.crypto.TextEncryptor;
 import org.craftercms.commons.crypto.impl.PbkAesTextEncryptor;
 import org.craftercms.studio.api.v1.constant.GitRepositories;
 import org.craftercms.studio.api.v1.constant.StudioConstants;
+import org.craftercms.studio.api.v1.ebus.PreviewEventContext;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepositoryCredentialsException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepositoryException;
@@ -180,6 +180,10 @@ public class StudioNodeSyncSandboxTask extends StudioNodeSyncBaseTask {
                     remoteLastSyncCommits.put(remoteNode.getGitRemoteName(), lastCommitId);
                 }
             }
+
+            PreviewEventContext context = new PreviewEventContext();
+            context.setSite(siteId);
+            eventService.publish(EVENT_PREVIEW_SYNC, context);
         } catch (GitAPIException e) {
             logger.error("Error while syncing cluster node content for site " + siteId);
         }

--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -586,6 +586,7 @@
         <property name="clusterDAO" ref="clusterDao" />
         <property name="repositoryType" value="SANDBOX" />
         <property name="deploymentService" ref="cstudioDeploymentService" />
+        <property name="eventService" ref="studioEventService" />
     </bean>
 
     <bean id="studioClusterPublishedSyncJob"


### PR DESCRIPTION
Added preview sync event for cluster sync nodes

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4180