### PR TITLE
[4200] [studio] Removing a remote doesn't remove the remote-tracking branches

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
@@ -48,12 +48,15 @@ import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.DeleteBranchCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.RemoteRemoveCommand;
 import org.eclipse.jgit.api.RmCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
@@ -1206,8 +1209,25 @@ public class GitContentRepository implements ContentRepository, DeploymentHistor
             Repository repo = helper.getRepository(siteId, SANDBOX);
             try (Git git = new Git(repo)) {
                 RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
-                remoteRemoveCommand.setName(remoteName);
+                remoteRemoveCommand.setRemoteName(remoteName);
                 remoteRemoveCommand.call();
+
+                List<Ref> resultRemoteBranches = git.branchList()
+                        .setListMode(ListBranchCommand.ListMode.REMOTE)
+                        .call();
+
+                List<String> branchesToDelete = new ArrayList<String>();
+                for (Ref remoteBranchRef : resultRemoteBranches) {
+                    if (remoteBranchRef.getName().startsWith(Constants.R_REMOTES + remoteName)) {
+                        branchesToDelete.add(remoteBranchRef.getName());
+                    }
+                }
+                if (CollectionUtils.isNotEmpty(branchesToDelete)) {
+                    DeleteBranchCommand delBranch = git.branchDelete();
+                    String[] array = new String[branchesToDelete.size()];
+                    delBranch.setBranchNames(branchesToDelete.toArray(array));
+                    delBranch.call();
+                }
 
             } catch (GitAPIException e) {
                 logger.error("Failed to remove remote " + remoteName + " for site " + siteId, e);


### PR DESCRIPTION
Fixed issue not cleaning up remote branch references

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4200