### PR TITLE
[4200] [studio] Removing a remote doesn't remove the remote-tracking branches

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
@@ -80,7 +80,9 @@ import org.craftercms.studio.api.v1.to.VersionTO;
 import org.craftercms.studio.api.v2.service.security.internal.UserServiceInternal;
 import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
+import org.eclipse.jgit.api.DeleteBranchCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.PullCommand;
 import org.eclipse.jgit.api.PullResult;
@@ -97,6 +99,7 @@ import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.internal.storage.file.LockFile;
 import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -1336,8 +1339,25 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
                 } finally {
                     if (!isValid) {
                         RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
-                        remoteRemoveCommand.setName(remoteName);
+                        remoteRemoveCommand.setRemoteName(remoteName);
                         remoteRemoveCommand.call();
+
+                        List<Ref> resultRemoteBranches = git.branchList()
+                                .setListMode(ListBranchCommand.ListMode.REMOTE)
+                                .call();
+
+                        List<String> branchesToDelete = new ArrayList<String>();
+                        for (Ref remoteBranchRef : resultRemoteBranches) {
+                            if (remoteBranchRef.getName().startsWith(Constants.R_REMOTES + remoteName)) {
+                                branchesToDelete.add(remoteBranchRef.getName());
+                            }
+                        }
+                        if (CollectionUtils.isNotEmpty(branchesToDelete)) {
+                            DeleteBranchCommand delBranch = git.branchDelete();
+                            String[] array = new String[branchesToDelete.size()];
+                            delBranch.setBranchNames(branchesToDelete.toArray(array));
+                            delBranch.call();
+                        }
                     }
                 }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
@@ -48,12 +48,15 @@ import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.DeleteBranchCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ListBranchCommand;
 import org.eclipse.jgit.api.RemoteRemoveCommand;
 import org.eclipse.jgit.api.RmCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
@@ -1206,8 +1209,25 @@ public class GitContentRepository implements ContentRepository, DeploymentHistor
             Repository repo = helper.getRepository(siteId, SANDBOX);
             try (Git git = new Git(repo)) {
                 RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
-                remoteRemoveCommand.setName(remoteName);
+                remoteRemoveCommand.setRemoteName(remoteName);
                 remoteRemoveCommand.call();
+
+                List<Ref> resultRemoteBranches = git.branchList()
+                        .setListMode(ListBranchCommand.ListMode.REMOTE)
+                        .call();
+
+                List<String> branchesToDelete = new ArrayList<String>();
+                for (Ref remoteBranchRef : resultRemoteBranches) {
+                    if (remoteBranchRef.getName().startsWith(Constants.R_REMOTES + remoteName)) {
+                        branchesToDelete.add(remoteBranchRef.getName());
+                    }
+                }
+                if (CollectionUtils.isNotEmpty(branchesToDelete)) {
+                    DeleteBranchCommand delBranch = git.branchDelete();
+                    String[] array = new String[branchesToDelete.size()];
+                    delBranch.setBranchNames(branchesToDelete.toArray(array));
+                    delBranch.call();
+                }
 
             } catch (GitAPIException e) {
                 logger.error("Failed to remove remote " + remoteName + " for site " + siteId, e);

--- a/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
@@ -43,6 +43,7 @@ import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.CommitCommand;
+import org.eclipse.jgit.api.DeleteBranchCommand;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
@@ -141,8 +142,26 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
                 } finally {
                     if (!isValid) {
                         RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
-                        remoteRemoveCommand.setName(remoteRepository.getRemoteName());
+                        remoteRemoveCommand.setRemoteName(remoteRepository.getRemoteName());
                         remoteRemoveCommand.call();
+
+                        List<Ref> resultRemoteBranches = git.branchList()
+                                .setListMode(ListBranchCommand.ListMode.REMOTE)
+                                .call();
+
+                        List<String> branchesToDelete = new ArrayList<String>();
+                        for (Ref remoteBranchRef : resultRemoteBranches) {
+                            if (remoteBranchRef.getName().startsWith(Constants.R_REMOTES +
+                                    remoteRepository.getRemoteName())) {
+                                branchesToDelete.add(remoteBranchRef.getName());
+                            }
+                        }
+                        if (CollectionUtils.isNotEmpty(branchesToDelete)) {
+                            DeleteBranchCommand delBranch = git.branchDelete();
+                            String[] array = new String[branchesToDelete.size()];
+                            delBranch.setBranchNames(branchesToDelete.toArray(array));
+                            delBranch.call();
+                        }
                     }
                 }
 
@@ -474,10 +493,26 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
         Repository repo = helper.getRepository(siteId, SANDBOX);
         try (Git git = new Git(repo)) {
             RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
-            remoteRemoveCommand.setName(remoteName);
+            remoteRemoveCommand.setRemoteName(remoteName);
             remoteRemoveCommand.call();
 
-        } catch (GitAPIException e) {
+            List<Ref> resultRemoteBranches = git.branchList()
+                    .setListMode(ListBranchCommand.ListMode.REMOTE)
+                    .call();
+
+            List<String> branchesToDelete = new ArrayList<String>();
+            for (Ref remoteBranchRef : resultRemoteBranches) {
+                if (remoteBranchRef.getName().startsWith(Constants.R_REMOTES + remoteName)) {
+                    branchesToDelete.add(remoteBranchRef.getName());
+                }
+            }
+            if (CollectionUtils.isNotEmpty(branchesToDelete)) {
+                DeleteBranchCommand delBranch = git.branchDelete();
+                String[] array = new String[branchesToDelete.size()];
+                delBranch.setBranchNames(branchesToDelete.toArray(array));
+                delBranch.call();
+            }
+        } catch (GitAPIException  e) {
             logger.error("Failed to remove remote " + remoteName + " for site " + siteId, e);
             return false;
         }


### PR DESCRIPTION
Fixed issue not cleaning up remote branch references

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4200