### PR TITLE
[4216] [studio] In a Studio cluster, a folder created in one node doesn't appear in the other node

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -603,6 +603,9 @@ public class ContentServiceImpl implements ContentService {
         boolean toRet = false;
         String commitId = _contentRepository.createFolder(site, path, name);
         if (commitId != null) {
+            contentRepository.insertGitLog(site, commitId, 1);
+            siteService.updateLastCommitId(site, commitId);
+
             SiteFeed siteFeed = siteService.getSite(site);
             AuditLog auditLog = auditServiceInternal.createAuditLogEntry();
             auditLog.setOperation(OPERATION_CREATE);


### PR DESCRIPTION
fixed sync issue caused by not setting last commit id when creating folder

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4216