### PR TITLE
[4221] [studio] Site creation doesn't continue properly when a HTTP url repo is sent with Private Key authentication

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
@@ -1296,7 +1296,12 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
                         throw new RemoteRepositoryNotFoundException("Remote repository not found: " + remoteName + " (" +
                                 remoteUrl + ")");
                     }
-                } catch (ServiceLayerException | IOException e) {
+                } catch (ClassCastException e) {
+                    logger.error("Wrong protocol used to access repository: " + remoteName +
+                            " (" + remoteUrl + ")", e);
+                    throw new InvalidRemoteRepositoryCredentialsException("Wrong protocol used to access repository: " +
+                            remoteName + " (" + remoteUrl + ")", e);
+                } catch (ServiceLayerException | IOException  e) {
                     logger.error("Failed to push newly created site " + siteId + " to remote repository " +
                             remoteUrl, e);
                     throw new ServiceLayerException(e);
@@ -1364,9 +1369,9 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
                     }
                 }
 
-            } catch (URISyntaxException e) {
+            } catch (URISyntaxException | ClassCastException e) {
                 logger.error("Remote URL is invalid " + remoteUrl, e);
-                throw new InvalidRemoteUrlException();
+                throw new InvalidRemoteUrlException("Remote URL is invalid " + remoteUrl, e);
             } catch (GitAPIException | IOException e) {
                 logger.error("Error while adding remote " + remoteName + " (url: " + remoteUrl + ") for site " +
                         siteId, e);


### PR DESCRIPTION
Fixed error handling to cover wrong protocol

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4221