### PR TITLE
[182E] [studio] node_last_verified_gitlog_commit_id is empty in cluster_site_sync_repo table

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/ClusterDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/ClusterDAO.java
@@ -203,6 +203,7 @@ public interface ClusterDAO {
 
     /**
      * get last commit id for node
+     * @param clusterNodeId cluster node identifier
      * @param siteId site identifier
      * @return last commit id for local studio node
      */
@@ -210,8 +211,17 @@ public interface ClusterDAO {
 
     /**
      * get last verified git log commit id for site
+     * @param clusterNodeId cluster node identifier
      * @param siteId site identifier
      * @return last verified git log commit id for local studio node
      */
     String getNodeLastVerifiedGitlogCommitId(@Param(CLUSTER_NODE_ID) long clusterNodeId, @Param(SITE_ID) long siteId);
+
+    /**
+     * Check if sync markers exists in DB
+     * @param clusterNodeId cluster node identifier
+     * @param siteId site identifier
+     * @return
+     */
+    int existsClusterSiteSyncRepo(@Param(CLUSTER_NODE_ID) long clusterNodeId, @Param(SITE_ID) long siteId);
 }

--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -449,6 +449,13 @@ public class SiteServiceImpl implements SiteService {
                 siteFeed.setSearchEngine(searchEngine);
                 siteFeedMapper.createSite(siteFeed);
 
+                String localeAddress = studioClusterUtils.getClusterNodeLocalAddress();
+                ClusterMember cm = clusterDao.getMemberByLocalAddress(localeAddress);
+                if (Objects.nonNull(cm)) {
+                    SiteFeed s = getSite(siteId);
+                    clusterDao.insertClusterSiteSyncRepo(cm.getId(), s.getId(), null, null);
+                }
+
                 logger.info("Upgrading site.");
                 upgradeManager.upgradeSite(siteId);
 

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
@@ -139,6 +139,10 @@ public class StudioClusterSandboxRepoSyncTask extends StudioClockClusterTask {
                         // Site doesn't exist locally, create it
                         success = createSite(localNode.getId(), siteFeed.getId(), siteId, siteFeed.getSiteUuid(),
                                 siteFeed.getSearchEngine(), clusterNodes);
+                    } else {
+                        if (clusterDao.existsClusterSiteSyncRepo(localNode.getId(), siteFeed.getId()) < 1) {
+                            clusterDao.insertClusterSiteSyncRepo(localNode.getId(), siteFeed.getId(), null, null);
+                        }
                     }
 
                     if (success) {

--- a/src/main/resources/org/craftercms/studio/api/v1/dal/SiteFeedMapper.xml
+++ b/src/main/resources/org/craftercms/studio/api/v1/dal/SiteFeedMapper.xml
@@ -86,19 +86,21 @@
     </update>
 
     <select id="getLastCommitId" resultType="java.lang.String">
-        SELECT IFNULL(cs.node_last_commit_id, s.last_commit_id)
-        FROM site s LEFT JOIN
-            (SELECT * FROM cluster c INNER JOIN cluster_site_sync_repo cssr ON c.id = cssr.cluster_node_id
-                WHERE c.local_address = #{localAddress}) AS cs ON s.id = cs.site_id
-        WHERE s.site_id = #{siteId} AND s.deleted = 0
+        SELECT IFNULL(NULLIF(TRIM(cs.node_last_commit_id), ''), s.last_commit_id)
+        FROM site s LEFT OUTER JOIN
+             (SELECT * FROM cluster_site_sync_repo cssr INNER JOIN cluster c ON cssr.cluster_node_id = c.id
+              WHERE c.local_address = #{localAddress}
+             ) AS cs ON s.id = cs.site_id
+        WHERE s.site_id = #{siteId}
     </select>
 
     <select id="getLastVerifiedGitlogCommitId" resultType="java.lang.String">
-        SELECT IFNULL(cs.node_last_verified_gitlog_commit_id, s.last_verified_gitlog_commit_id)
-        FROM site s LEFT JOIN
-             (SELECT * FROM cluster c INNER JOIN cluster_site_sync_repo cssr ON c.id = cssr.cluster_node_id
-              WHERE c.local_address = #{localAddress}) AS cs ON s.id = cs.site_id
-        WHERE s.site_id = #{siteId} AND s.deleted = 0
+        SELECT IFNULL(NULLIF(TRIM(cs.node_last_verified_gitlog_commit_id), ''), s.last_verified_gitlog_commit_id)
+        FROM site s LEFT OUTER JOIN
+            (SELECT * FROM cluster_site_sync_repo cssr INNER JOIN cluster c ON cssr.cluster_node_id = c.id
+                WHERE c.local_address = #{localAddress}
+            ) AS cs ON s.id = cs.site_id
+        WHERE s.site_id = #{siteId}
     </select>
 
     <select id="exists" parameterType="java.lang.String" resultType="int">

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ClusterDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ClusterDAO.xml
@@ -172,4 +172,12 @@
         WHERE c.id = #{clusterNodeId}
         AND cssr.site_id = #{siteId} AND s.deleted = 0 limit 1
     </select>
+
+    <select id="existsClusterSiteSyncRepo" resultType="int">
+        SELECT count(1)
+        FROM site s INNER JOIN cluster_site_sync_repo cssr INNER JOIN cluster c
+        ON s.id = cssr.site_id AND cssr.cluster_node_id = c.id
+        WHERE s.id = #{siteId}
+        AND c.id = #{clusterNodeId}
+    </select>
 </mapper>


### PR DESCRIPTION
Fixed issues with sync markers

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/182