### PR TITLE
[182E] [studio] node_last_verified_gitlog_commit_id is empty in cluster_site_sync_repo table.

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -1167,6 +1167,8 @@ public class SiteServiceImpl implements SiteService {
                 if (CollectionUtils.isEmpty(repoOperations)) {
                     logger.debug("Database is up to date with repository for site: " + site);
                     contentRepositoryV2.markGitLogVerifiedProcessed(site, fromCommitId);
+                    updateLastCommitId(site, repoLastCommitId);
+                    updateLastVerifiedGitlogCommitId(site, repoLastCommitId);
                     return toReturn;
                 }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
@@ -139,11 +139,11 @@ public class StudioClusterSandboxRepoSyncTask extends StudioClockClusterTask {
                         // Site doesn't exist locally, create it
                         success = createSite(localNode.getId(), siteFeed.getId(), siteId, siteFeed.getSiteUuid(),
                                 siteFeed.getSearchEngine(), clusterNodes);
-                    } else {
-                        if (clusterDao.existsClusterSiteSyncRepo(localNode.getId(), siteFeed.getId()) < 1) {
-                            clusterDao.insertClusterSiteSyncRepo(localNode.getId(), siteFeed.getId(), null, null);
-                        }
                     }
+                    if (clusterDao.existsClusterSiteSyncRepo(localNode.getId(), siteFeed.getId()) < 1) {
+                        clusterDao.insertClusterSiteSyncRepo(localNode.getId(), siteFeed.getId(), null, null);
+                    }
+
 
                     if (success) {
                         syncRemoteRepositories(siteId, localAddress);


### PR DESCRIPTION
Fixed markers null values and restart removes markers

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/182