### PR TITLE
[182E] [studio] node_last_verified_gitlog_commit_id is empty in cluster_site_sync_repo table

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -1795,7 +1795,7 @@ public class SiteServiceImpl implements SiteService {
     @Override
     public boolean tryLockSyncRepoForSite(String siteId, String lockOwnerId, int ttl) {
         logger.debug("Locking sync repo for site " + siteId + " with lock owner " + lockOwnerId);
-        int result = siteFeedMapper.tryLockPublishingForSite(siteId, lockOwnerId, ttl);
+        int result = siteFeedMapper.tryLockSyncRepoForSite(siteId, lockOwnerId, ttl);
         if (result == 1) {
             logger.debug("Locked sync repo for site " + siteId + " with lock owner " + lockOwnerId);
         } else {


### PR DESCRIPTION
Fixed wrong lock being called for sync repo

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/182