### PR TITLE
[182E] [studio] node_last_verified_gitlog_commit_id is empty in cluster_site_sync_repo table

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
@@ -327,6 +327,8 @@ public interface StudioConfiguration {
     String CLOCK_JOB_TASK_EXECUTOR_CORE_POOL_SIZE = "studio.clockJob.taskExecutor.corePoolSize";
     String CLOCK_JOB_TASK_EXECUTOR_MAX_POOL_SIZE = "studio.clockJob.taskExecutor.maxPoolSize";
     String CLOCK_JOB_TASK_EXECUTOR_QUEUE_CAPACITY = "studio.clockJob.taskExecutor.queueCapacity";
+    String CLOCK_JOB_TASK_CLUSTER_RANDOM_OFFSET =
+            "studio.clockJob.task.cluster.randomOffset";
     String CLOCK_JOB_TASK_CLUSTER_GLOBAL_REPO_SYNC_EXECUTE_EVERY_N_CYCLES =
             "studio.clockJob.task.cluster.globalRepoSync.executeEveryNCycles";
     String CLOCK_JOB_TASK_CLUSTER_SITE_SANDBOX_REPO_SYNC_EXECUTE_EVERY_N_CYCLES =

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockClusterTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockClusterTask.java
@@ -52,10 +52,11 @@ public abstract class StudioClockClusterTask extends StudioClockTask {
     protected abstract List<String> getCreatedSites();
 
     public StudioClockClusterTask(int executeEveryNCycles,
+                                  int offset,
                                   StudioConfiguration studioConfiguration,
                                   SiteService siteService,
                                   ContentRepository contentRepository) {
-        super(executeEveryNCycles, studioConfiguration, siteService);
+        super(executeEveryNCycles, offset, studioConfiguration, siteService);
         this.contentRepository = contentRepository;
     }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockTask.java
@@ -28,14 +28,17 @@ public abstract class StudioClockTask implements SiteJob {
 
     private int executeEveryNCycles;
     protected int counter;
+    protected int offset;
     protected StudioConfiguration studioConfiguration;
     protected SiteService siteService;
 
     public StudioClockTask(int executeEveryNCycles,
+                           int offset,
                            StudioConfiguration studioConfiguration,
                            SiteService siteService) {
         this.executeEveryNCycles = executeEveryNCycles;
         this.counter = executeEveryNCycles;
+        this.offset = offset;
         this.studioConfiguration = studioConfiguration;
         this.siteService = siteService;
     }
@@ -53,6 +56,13 @@ public abstract class StudioClockTask implements SiteJob {
         if (checkCycleCounter()) {
             if (lockSiteInternal(site)) {
                 try {
+                    try {
+                        long sleepTime = (long) (Math.random() * offset);
+                        logger.debug("Sleeping for offset " + sleepTime + " milliseconds");
+                        Thread.sleep(sleepTime);
+                    } catch (InterruptedException e) {
+                        logger.debug("Woke up from random offset");
+                    }
                     executeInternal(site);
                     counter = executeEveryNCycles;
                 } finally {

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterPublishedRepoSyncTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterPublishedRepoSyncTask.java
@@ -99,6 +99,7 @@ public class StudioClusterPublishedRepoSyncTask extends StudioClockClusterTask {
     private TextEncryptor encryptor;
 
     public StudioClusterPublishedRepoSyncTask(int executeEveryNCycles,
+                                              int offset,
                                               StudioClusterUtils studioClusterUtils,
                                               StudioConfiguration studioConfiguration,
                                               ContentRepository contentRepository,
@@ -109,7 +110,7 @@ public class StudioClusterPublishedRepoSyncTask extends StudioClockClusterTask {
                                               UserServiceInternal userServiceInternal,
                                               TextEncryptor encryptor) {
 
-        super(executeEveryNCycles, studioConfiguration, siteService, contentRepository);
+        super(executeEveryNCycles, offset, studioConfiguration, siteService, contentRepository);
         this.studioClusterUtils = studioClusterUtils;
         this.clusterDao = clusterDao;
         this.servicesConfig = servicesConfig;

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterSandboxRepoSyncTask.java
@@ -100,6 +100,7 @@ public class StudioClusterSandboxRepoSyncTask extends StudioClockClusterTask {
     private ClusterDAO clusterDao;
 
     public StudioClusterSandboxRepoSyncTask(int executeEveryNCycles,
+                                            int offset,
                                             StudioClusterUtils studioClusterUtils,
                                             StudioConfiguration studioConfiguration,
                                             ContentRepository contentRepository,
@@ -108,7 +109,7 @@ public class StudioClusterSandboxRepoSyncTask extends StudioClockClusterTask {
                                             DeploymentService deploymentService,
                                             EventService eventService,
                                             ClusterDAO clusterDao) {
-        super(executeEveryNCycles, studioConfiguration, siteService, contentRepository);
+        super(executeEveryNCycles, offset, studioConfiguration, siteService, contentRepository);
         this.studioClusterUtils = studioClusterUtils;
         this.deployer = deployer;
         this.deploymentService = deploymentService;

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioPublisherTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioPublisherTask.java
@@ -78,6 +78,7 @@ public class StudioPublisherTask extends StudioClockTask {
     private StudioClusterUtils studioClusterUtils;
 
     public StudioPublisherTask(int executeEveryNCycles,
+                               int offset,
                                StudioConfiguration studioConfiguration,
                                SiteService siteService,
                                ContentRepository contentRepository,
@@ -87,7 +88,7 @@ public class StudioPublisherTask extends StudioClockTask {
                                AuditServiceInternal auditServiceInternal,
                                int maxRetryCounter,
                                StudioClusterUtils studioClusterUtils) {
-        super(executeEveryNCycles, studioConfiguration, siteService);
+        super(executeEveryNCycles, offset, studioConfiguration, siteService);
         this.studioConfiguration = studioConfiguration;
         this.siteService = siteService;
         this.contentRepository = contentRepository;

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioSyncRepositoryTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioSyncRepositoryTask.java
@@ -44,9 +44,10 @@ public class StudioSyncRepositoryTask extends StudioClockTask {
     protected static final Map<String, ReentrantLock> singleWorkerLockMap = new HashMap<String, ReentrantLock>();
 
     public StudioSyncRepositoryTask(int executeEveryNCycles,
+                                    int offset,
                                     StudioConfiguration studioConfiguration,
                                     SiteService siteService) {
-        super(executeEveryNCycles, studioConfiguration, siteService);
+        super(executeEveryNCycles, offset, studioConfiguration, siteService);
     }
 
     @Override

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -827,6 +827,8 @@ studio.forwarded.headers.enabled: false
 ##################################################
 # Studio Clock job ticking frequency
 studio.clockJob.frequency: 1000
+# Random offset to time shift cluster members in milliseconds
+studio.clockJob.task.cluster.randomOffset: 10
 # Studio Clock Job thread pool core size
 studio.clockJob.taskExecutor.corePoolSize: 10
 # Studio Clock Job thread pool maximum size

--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -618,6 +618,8 @@
           class="org.craftercms.studio.impl.v2.job.StudioClusterSandboxRepoSyncTask">
         <constructor-arg name="executeEveryNCycles"
                          value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_SITE_SANDBOX_REPO_SYNC_EXECUTE_EVERY_N_CYCLES)}" />
+        <constructor-arg name="offset"
+                         value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_RANDOM_OFFSET)}" />
         <constructor-arg name="studioClusterUtils" ref="studio.clusterUtils" />
         <constructor-arg name="studioConfiguration" ref="studioConfiguration" />
         <constructor-arg name="contentRepository" ref="contentRepository" />
@@ -632,6 +634,8 @@
           class="org.craftercms.studio.impl.v2.job.StudioClusterPublishedRepoSyncTask">
         <constructor-arg name="executeEveryNCycles"
                          value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_SITE_PUBLISHED_REPO_SYNC_EXECUTE_EVERY_N_CYCLES)}" />
+        <constructor-arg name="offset"
+                         value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_RANDOM_OFFSET)}" />
         <constructor-arg name="studioClusterUtils" ref="studio.clusterUtils" />
         <constructor-arg name="studioConfiguration" ref="studioConfiguration" />
         <constructor-arg name="contentRepository" ref="contentRepository" />
@@ -646,6 +650,8 @@
     <bean id="studio.clockSyncRepositoryTask" class="org.craftercms.studio.impl.v2.job.StudioSyncRepositoryTask">
         <constructor-arg name="executeEveryNCycles"
                          value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_SYNC_REPOSITORY_EXECUTE_EVERY_N_CYCLES)}" />
+        <constructor-arg name="offset"
+                         value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_RANDOM_OFFSET)}" />
         <constructor-arg name="studioConfiguration" ref="studioConfiguration" />
         <constructor-arg name="siteService" ref="cstudioSiteServiceSimple" />
     </bean>
@@ -653,6 +659,8 @@
     <bean id="studio.clockPublisherTask" class="org.craftercms.studio.impl.v2.job.StudioPublisherTask" >
         <constructor-arg name="executeEveryNCycles"
                          value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_PUBLISHER_EXECUTE_EVERY_N_CYCLES)}" />
+        <constructor-arg name="offset"
+                         value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_CLUSTER_RANDOM_OFFSET)}" />
         <constructor-arg name="maxRetryCounter"
                          value="#{studioConfiguration.getProperty(T(org.craftercms.studio.api.v2.utils.StudioConfiguration).CLOCK_JOB_TASK_PUBLISHER_MAX_RETRY_COUNT)}" />
         <constructor-arg name="studioConfiguration" ref="studioConfiguration" />


### PR DESCRIPTION
Added offset for clock tasks to avoid starvation

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/182