### PR TITLE
[182E] [studio] node_last_verified_gitlog_commit_id is empty in cluster_site_sync_repo table

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
@@ -526,7 +526,7 @@ public class GitRepositoryHelper {
         Path siteSandboxPath = buildRepoPath(GitRepositories.SANDBOX, site);
 
         // Create Sandbox
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             sandboxRepo = createGitRepository(siteSandboxPath);
@@ -559,7 +559,7 @@ public class GitRepositoryHelper {
         Path siteSandboxPath = buildRepoPath(GitRepositories.SANDBOX, siteId);
         // Built a path for the site/published
         Path sitePublishedPath = buildRepoPath(GitRepositories.PUBLISHED, siteId);
-        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git publishedGit = Git.cloneRepository()
                 .setURI(sitePublishedPath.relativize(siteSandboxPath).toString())
@@ -785,7 +785,7 @@ public class GitRepositoryHelper {
         boolean toReturn = true;
 
         Repository repo = getRepository(site, GitRepositories.SANDBOX, sandboxBranch);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
 
@@ -835,7 +835,7 @@ public class GitRepositoryHelper {
         logger.debug("Cloning from " + remoteUrl + " to " + localPath);
         CloneCommand cloneCommand = Git.cloneRepository();
         Git cloneResult = null;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try {
             final Path tempKey = Files.createTempFile(UUID.randomUUID().toString(),".tmp");
@@ -1061,8 +1061,8 @@ public class GitRepositoryHelper {
         // Get a file handle to the parent and delete it
         File siteFolder = sitePath.toFile();
 
-        String gitLockKeySandbox = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
-        String gitLockKeyPublished = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKeySandbox = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
+        String gitLockKeyPublished = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKeySandbox);
         generalLockService.lock(gitLockKeyPublished);
         try {
@@ -1164,7 +1164,7 @@ public class GitRepositoryHelper {
         String gitPath = getGitPath(path);
         Status status;
 
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             status = git.status().addPath(gitPath).call();

--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
@@ -278,9 +278,6 @@ public interface StudioConfiguration {
     String CLUSTERING_SYNC_URL_FORMAT = "studio.clustering.sync.urlFormat";
 
     /** Clustering Thread Pool **/
-    String CLUSTERING_SANDBOX_SYNC_JOB_INTERVAL = "studio.clustering.sandboxSyncJob.interval";
-    String CLUSTERING_PUBLISHED_SYNC_JOB_INTERVAL = "studio.clustering.publishedSyncJob.interval";
-    String CLUSTERING_GLOBAL_REPO_SYNC_JOB_INTERVAL = "studio.clustering.globalRepoSyncJob.interval";
     String CLUSTERING_HEARTBEAT_JOB_INTERVAL = "studio.clustering.heartbeatJob.interval";
     String CLUSTERING_INACTIVITY_CHECK_JOB_INTERVAL = "studio.clustering.inactivityCheckJob.interval";
     String CLUSTERING_HEARTBEAT_STALE_TIME_LIMIT = "studio.clustering.heartbeatStale.timeLimit";

--- a/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/repository/git/GitContentRepository.java
@@ -290,7 +290,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     public String writeContent(String site, String path, InputStream content) {
         // Write content to git and commit it
         String commitId = null;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -327,7 +327,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
         // SJ: Git doesn't care about empty folders, so we will create the folders and put a 0 byte file in them
         String commitId = null;
         boolean result;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -395,7 +395,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     public String deleteContent(String site, String path, String approver) {
         String commitId = null;
         boolean isPage = path.endsWith(FILE_SEPARATOR + INDEX_FILE);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -475,7 +475,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     public Map<String, String> moveContent(String site, String fromPath, String toPath, String newName) {
         Map<String, String> toRet = new TreeMap<String, String>();
         String commitId;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -564,7 +564,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     @Override
     public String copyContent(String site, String fromPath, String toPath) {
         String commitId = null;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -746,7 +746,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
         // SJ: Major revisions become git tags
         // TODO: SJ: Redesign/refactor the whole approach in 3.1+
         String toReturn = EMPTY;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -793,7 +793,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     public String revertContent(String site, String path, String version, boolean major, String comment) {
         // TODO: SJ: refactor to remove the notion of a major/minor for 3.1+
         String commitId = null;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             InputStream versionContent = getContentVersion(site, path, version);
@@ -1026,7 +1026,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     @Override
     public boolean deleteSite(String site) {
         boolean toReturn;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -1067,7 +1067,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
     @Override
     public void initialPublish(String site, String sandboxBranch, String environment, String author, String comment)
             throws DeploymentException, CryptoException {
-        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(site, PUBLISHED);
@@ -1287,7 +1287,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
             throws InvalidRemoteRepositoryException, InvalidRemoteRepositoryCredentialsException,
             RemoteRepositoryNotFoundException, RemoteRepositoryNotBareException, ServiceLayerException {
         boolean toRet = true;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -1804,7 +1804,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(siteId, SANDBOX);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             PullResult pullResult = null;
@@ -1917,7 +1917,7 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
         Repository repo = helper.getRepository(siteId, PUBLISHED);
         String stagingName = servicesConfig.getStagingEnvironment(siteId);
         String liveName = servicesConfig.getLiveEnvironment(siteId);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         synchronized (repo) {
             try (Git git = new Git(repo)) {
@@ -1981,8 +1981,8 @@ public class GitContentRepository implements ContentRepository, ServletContextAw
             }
         } else {
             logger.info("Cleaning up repositories for site {0}", siteId);
-            String gitLockKeySandbox = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
-            String gitLockKeyPublished = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+            String gitLockKeySandbox = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
+            String gitLockKeyPublished = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
             generalLockService.lock(gitLockKeySandbox);
             try {
                 cleanup(siteId, SANDBOX);

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockClusterTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClockClusterTask.java
@@ -17,7 +17,6 @@
 package org.craftercms.studio.impl.v2.job;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.craftercms.studio.api.v1.log.Logger;
 import org.craftercms.studio.api.v1.log.LoggerFactory;
 import org.craftercms.studio.api.v1.repository.ContentRepository;
@@ -30,16 +29,9 @@ import org.eclipse.jgit.api.RemoteRemoveCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
-import static org.craftercms.studio.impl.v1.repository.git.GitContentRepositoryConstants.GIT_ROOT;
 
 public abstract class StudioClockClusterTask extends StudioClockTask {
 

--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioSyncRepositoryTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioSyncRepositoryTask.java
@@ -37,18 +37,22 @@ import static org.craftercms.studio.api.v2.utils.StudioConfiguration.SITES_REPOS
 public class StudioSyncRepositoryTask extends StudioClockTask {
 
     private static final Logger logger = LoggerFactory.getLogger(StudioSyncRepositoryTask.class);
+    private static int threadCounter = 0;
 
     public StudioSyncRepositoryTask(int executeEveryNCycles,
                                     int offset,
                                     StudioConfiguration studioConfiguration,
                                     SiteService siteService) {
         super(executeEveryNCycles, offset, studioConfiguration, siteService);
+        threadCounter++;
     }
 
     @Override
     protected void executeInternal(String site) {
         try {
             try {
+                logger.debug("Executing sync repository thread ID = " + threadCounter + "; " +
+                        Thread.currentThread().getId());
                 syncRepository(site);
             } catch (Exception e) {
                 logger.error("Failed to sync database from repository for site " + site, e);

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepository.java
@@ -722,7 +722,7 @@ public class GitContentRepository implements ContentRepository, DeploymentHistor
     public boolean createSiteFromBlueprint(String blueprintLocation, String site, String sandboxBranch,
                                            Map<String, String> params) {
         boolean toReturn;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -865,7 +865,7 @@ public class GitContentRepository implements ContentRepository, DeploymentHistor
             return;
         }
         String commitId = EMPTY;
-        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_PUBLISHED_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -1222,7 +1222,7 @@ public class GitContentRepository implements ContentRepository, DeploymentHistor
         // clone remote git repository for site content
         logger.debug("Creating site " + siteId + " as a clone of remote repository " + remoteName +
                 " (" + remoteUrl + ").");
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,

--- a/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
@@ -126,7 +126,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
     public boolean addRemote(String siteId, RemoteRepository remoteRepository)
             throws ServiceLayerException, InvalidRemoteUrlException {
         boolean isValid = false;
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try {
             logger.debug("Add remote " + remoteRepository.getRemoteName() + " to the sandbox repo for the site " + siteId);
@@ -377,7 +377,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
     public boolean pullFromRemote(String siteId, String remoteName, String remoteBranch, String mergeStrategy)
             throws InvalidRemoteUrlException, ServiceLayerException, CryptoException {
         logger.debug("Get remote data from database for remote " + remoteName + " and site " + siteId);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         RemoteRepository remoteRepository = getRemoteRepository(siteId, remoteName);
         logger.debug("Prepare pull command");
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
@@ -518,7 +518,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(siteId, SANDBOX);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             RemoteRemoveCommand remoteRemoveCommand = git.remoteRemove();
@@ -599,7 +599,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(siteId, SANDBOX);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             switch (resolution.toLowerCase()) {
@@ -702,7 +702,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(siteId, SANDBOX);
         logger.debug("Commit resolution for merge conflict for site " + siteId);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             Status status = git.status().call();
@@ -745,7 +745,7 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
         GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,
                 userServiceInternal, encryptor, generalLockService);
         Repository repo = helper.getRepository(siteId, SANDBOX);
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, siteId);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, siteId);
         generalLockService.lock(gitLockKey);
         try (Git git = new Git(repo)) {
             git.reset().setMode(ResetCommand.ResetType.HARD).call();

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/AbstractUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/AbstractUpgradeOperation.java
@@ -185,7 +185,7 @@ public abstract class AbstractUpgradeOperation implements UpgradeOperation, Serv
     }
 
     protected void writeToRepo(String site, String path, InputStream content) {
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             Path repositoryPath = getRepositoryPath(site);
@@ -257,7 +257,7 @@ public abstract class AbstractUpgradeOperation implements UpgradeOperation, Serv
     }
 
     protected void commitAllChanges(String site) throws UpgradeException {
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             Path repositoryPath = getRepositoryPath(site);

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/global/BlueprintsUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/global/BlueprintsUpgradeOperation.java
@@ -111,7 +111,7 @@ public class BlueprintsUpgradeOperation extends AbstractUpgradeOperation {
 
     @Override
     public void execute(final String site) throws UpgradeException {
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/pipeline/SiteRepositoryUpgradePipelineImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/pipeline/SiteRepositoryUpgradePipelineImpl.java
@@ -110,7 +110,7 @@ public class SiteRepositoryUpgradePipelineImpl extends DefaultUpgradePipelineImp
      */
     @Override
     public void execute(final String site) throws UpgradeException {
-        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replace(PATTERN_SITE, site);
+        String gitLockKey = SITE_SANDBOX_REPOSITORY_GIT_LOCK.replaceAll(PATTERN_SITE, site);
         generalLockService.lock(gitLockKey);
         try {
             GitRepositoryHelper helper = GitRepositoryHelper.getHelper(studioConfiguration, securityService,

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -568,12 +568,6 @@ studio.clustering.sync.urlFormat: ssh://{username}@{localAddress}{absolutePath}
 ################################################################
 ##                   Clustering Thread Pool                   ##
 ################################################################
-# Sandbox Sync Job interval in milliseconds which is how often to sync the work-area
-studio.clustering.sandboxSyncJob.interval: 5000
-# Published Sync Job interval in milliseconds which is how often to sync the published repos
-studio.clustering.publishedSyncJob.interval: 60000
-# Global Repo Sync Job interval in milliseconds which is how often to sync the global repo
-studio.clustering.globalRepoSyncJob.interval: 45000
 # Heartbeat Job interval in milliseconds which is how often to update cluster member's heartbeat in DB
 studio.clustering.heartbeatJob.interval: 10000
 # Inactivity Check Job interval in milliseconds which is how often to to check for inactive cluster members


### PR DESCRIPTION
Fixed lock key bug. Cleanup properties. Adding more logs to track locking

### Ticket reference or full description of what's in the PR
