### PR TITLE
[196E] [studio] Shutting down and starting up cluster nodes cause that the value of site_published_repo_created get resseted

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterPublishedRepoSyncTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/job/StudioClusterPublishedRepoSyncTask.java
@@ -151,6 +151,8 @@ public class StudioClusterPublishedRepoSyncTask extends StudioClockClusterTask {
                     if (!siteCheck) {
                         // Site doesn't exist locally, create it
                         success = createSite(localNode.getId(), siteFeed.getId(), siteId, siteFeed.getSandboxBranch());
+                    } else {
+                        clusterDao.setPublishedRepoCreated(localNode.getId(), siteFeed.getId());
                     }
                 } else {
                     success = false;
@@ -419,7 +421,7 @@ public class StudioClusterPublishedRepoSyncTask extends StudioClockClusterTask {
                 pullCommand.setRemoteBranchName(branch);
                 pullCommand = studioClusterUtils.configureAuthenticationForCommand(remoteNode, pullCommand, tempKey);
                 pullCommand.call();
-                
+
             } finally {
                 generalLockService.unlock(gitLockKey);
             }


### PR DESCRIPTION
Fixed cluster node restart issue

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/196