### PR TITLE
[211E] [studio] Cluster: When a node is dropped from cluster, data folder should be removed to start up correctly

### DIFF
--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ClusterDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ClusterDAO.xml
@@ -163,6 +163,9 @@
     <insert id="addClusterRemoteRepository">
         INSERT INTO cluster_remote_repository (cluster_id, remote_repository_id)
         VALUES (#{clusterId}, #{remoteRepositoryId})
+        ON DUPLICATE KEY
+        UPDATE
+            record_last_updated = CURRENT_TIMESTAMP
     </insert>
 
     <select id="getMemberByLocalAddress" resultMap="ClusterMap" parameterType="java.util.Map">


### PR DESCRIPTION
Fixed issue

### Ticket reference or full description of what's in the PR
https://github.com/craftersoftware/craftercms/issues/211