### PR TITLE
[4515] [studio] children_by_path is returning non-existing items

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -498,7 +498,14 @@ public class SiteServiceImpl implements SiteService {
 
                 User userObj = userServiceInternal.getUserByGitName(creator);
 
-                createdFiles.keySet().forEach(path -> {
+                createdFiles.forEach((k, v) -> {
+                    if (StringUtils.equals("D", v)) {
+                        return;
+                    }
+                    String path = k;
+                    if (v.length() > 1) {
+                        path = v;
+                    }
                     objectStateService.insertNewEntry(siteId, path);
                     objectMetadataManager.insertNewObjectMetadata(siteId, path);
                     Map<String, Object> properties = new HashMap<String, Object>();
@@ -859,7 +866,14 @@ public class SiteServiceImpl implements SiteService {
 
                 User userObj = userServiceInternal.getUserByGitName(creator);
 
-                createdFiles.keySet().forEach(path -> {
+                createdFiles.forEach((k, v) -> {
+                    if (StringUtils.equals("D", v)) {
+                        return;
+                    }
+                    String path = k;
+                    if (v.length() > 1) {
+                        path = v;
+                    }
                     objectStateService.insertNewEntry(siteId, path);
                     objectMetadataManager.insertNewObjectMetadata(siteId, path);
                     Map<String, Object> properties = new HashMap<String, Object>();
@@ -912,6 +926,7 @@ public class SiteServiceImpl implements SiteService {
 
                 logger.info("Loading configuration for site " + siteId);
                 reloadSiteConfiguration(siteId);
+                itemServiceInternal.updateParentIds(siteId, StringUtils.EMPTY);
             } catch (Exception e) {
                 success = false;
                 logger.error("Error while creating site: " + siteId + " ID: " + siteId + " as clone from " +
@@ -1063,7 +1078,14 @@ public class SiteServiceImpl implements SiteService {
 
                     User userObj = userServiceInternal.getUserByGitName(creator);
 
-                    createdFiles.keySet().forEach(path -> {
+                    createdFiles.forEach((k, v) -> {
+                        if (StringUtils.equals("D", v)) {
+                            return;
+                        }
+                        String path = k;
+                        if (v.length() > 1) {
+                            path = v;
+                        }
                         objectStateService.insertNewEntry(siteId, path);
                         objectMetadataManager.insertNewObjectMetadata(siteId, path);
                         Map<String, Object> properties = new HashMap<String, Object>();
@@ -1117,6 +1139,7 @@ public class SiteServiceImpl implements SiteService {
 
                     logger.info("Loading configuration for site " + siteId);
                     reloadSiteConfiguration(siteId);
+                    itemServiceInternal.updateParentIds(siteId, StringUtils.EMPTY);
                 } catch (Exception e) {
                     success = false;
                     logger.error("Error while creating site: " + siteId + " ID: " + siteId + " from blueprint: " +


### PR DESCRIPTION
Fixed issue caused by the wrong use of changeset when creating the site as a clone from remote

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4515