### PR TITLE
[4561] [studio] Cluster doesn't work with HTTPs repo URLs and basic auth

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterUtils.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/cluster/StudioClusterUtils.java
@@ -172,6 +172,8 @@ public class StudioClusterUtils {
                 });
             });
         }
+
+        gitCommand.setCredentialsProvider(credentialsProvider);
     }
 
     private <T extends TransportCommand> void configureTokenAuthentication(


### PR DESCRIPTION
Fixed basic auth over https issue

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4561