### PR TITLE
Fixes for site policy:

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/annotation/policy/SitePolicyAspect.java
+++ b/src/main/java/org/craftercms/studio/api/v2/annotation/policy/SitePolicyAspect.java
@@ -15,7 +15,6 @@
  */
 package org.craftercms.studio.api.v2.annotation.policy;
 
-import org.apache.commons.io.FilenameUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -33,6 +32,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static java.util.function.Predicate.not;
+import static org.apache.commons.io.FilenameUtils.getFullPathNoEndSeparator;
+import static org.apache.commons.io.FilenameUtils.getName;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.craftercms.studio.model.policy.Action.METADATA_CONTENT_TYPE;
 
@@ -125,8 +126,8 @@ public class SitePolicyAspect {
         if (modified.isPresent()) {
             var newArgs = pjp.getArgs();
             if (isNotEmpty(targetFilename)) {
-                newArgs[targetPathPosition] = FilenameUtils.getFullPath(modified.get().getModifiedValue());
-                newArgs[targetFilenamePosition] = FilenameUtils.getName(modified.get().getModifiedValue());
+                newArgs[targetPathPosition] = getFullPathNoEndSeparator(modified.get().getModifiedValue());
+                newArgs[targetFilenamePosition] = getName(modified.get().getModifiedValue());
             } else {
                 newArgs[targetPathPosition] = modified.get().getModifiedValue();
             }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/policy/validators/ContentTypePolicyValidator.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/policy/validators/ContentTypePolicyValidator.java
@@ -44,14 +44,12 @@ public class ContentTypePolicyValidator implements PolicyValidator {
             return;
         }
 
-        var contentType = action.<String>getMetadata(Action.METADATA_CONTENT_TYPE);
-
-        if (isEmpty(contentType)) {
-            logger.debug("Skipping action that doesn't contain a Content-Type");
-            return;
-        }
-
         if (config.containsKey(CONFIG_KEY_CONTENT_TYPES)) {
+            String contentType = action.getMetadata(Action.METADATA_CONTENT_TYPE);
+            if (isEmpty(contentType)) {
+                throw new ValidationException("Content-Type is required for validation");
+            }
+
             var allowedTypes = config.getList(String.class, CONFIG_KEY_CONTENT_TYPES);
 
             if (!allowedTypes.contains(contentType)) {

--- a/src/test/resources/crafter/studio/config/policy.xml
+++ b/src/test/resources/crafter/studio/config/policy.xml
@@ -72,7 +72,7 @@
     <statement>
         <target-path-pattern>/site/components/headers.*</target-path-pattern>
         <permitted>
-            <content-types>/component/header</content-types>
+            <content-types>/component/header,/component/test</content-types>
         </permitted>
     </statement>
 


### PR DESCRIPTION
- Validate all sections of paths instead of just the filename
- Avoid repeated slash when intercepting operations
- Support comma separated lists in the configuration
- Make content-type required according to the configuration

https://github.com/craftercms/craftercms/issues/4354
