### PR TITLE
[4903] [studio] Available publishing targets API returns possibly cached result from previous site

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -873,6 +873,9 @@ public class SiteServiceImpl implements SiteService {
             logger.error("Failed to delete the repository for site:" + siteId, e);
         }
 
+        // clear cache
+        configurationService.invalidateConfiguration(siteId);
+
         try {
             // delete database records
             logger.debug("Deleting database records");


### PR DESCRIPTION
Fixed issue. The cache was not being cleared on site delete

### Ticket reference or a full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4903