### PR TITLE
[4935] [studio] Unable to create level descriptor

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -338,8 +338,7 @@ public class ContentServiceImpl implements ContentService {
                              @ValidateStringParam(name = "edit") String edit,
                              @ValidateStringParam(name = "unlock") String unlock,
                              boolean skipAuditLogInsert) throws ServiceLayerException {
-        // TODO: SJ: refactor for 2.7.x
-
+        path = path.replaceAll("//", "/");
         try {
             entitlementValidator.validateEntitlement(EntitlementType.ITEM, 1);
         } catch (EntitlementException e) {


### PR DESCRIPTION
Fixed bug caused by UI sending double slash in the target path

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4935