### PR TITLE
[4951] [studio] Filtered publish queue results are displayed out of order

### DIFF
--- a/src/main/resources/org/craftercms/studio/api/v2/dal/PublishRequestDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/PublishRequestDAO.xml
@@ -82,6 +82,7 @@
             and path RLIKE #{path}
         </if>
         GROUP BY package_id
+        ORDER BY published_on DESC, scheduleddate DESC
         LIMIT #{offset}, #{limit}
     </select>
 


### PR DESCRIPTION
Added default sort order for publishing queue filtering

### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/4951