### PR TITLE
[5574] Editorial blueprint - Show Social Media Widget component only under components

### DIFF
--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/content-types/component/social-media-widget/config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/content-types/component/social-media-widget/config.xml
@@ -10,4 +10,9 @@
 	<quickCreatePath />
 	<noThumbnail>true</noThumbnail>
 	<image-thumbnail />
+	<paths>
+		<includes>
+			<pattern>^/site/components/.*</pattern>
+		</includes>
+	</paths>
 </content-type>


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5574