### PR TITLE
[5604] Rollback invoking EnvOverrides.getSiteValues everywhere

### DIFF
--- a/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
+++ b/src/main/webapp/default-site/scripts/libs/EnvironmentOverrides.groovy
@@ -136,4 +136,12 @@ class EnvironmentOverrides {
 
     return result;
   }
+
+  static getMinimalValuesForSite(appContext, request) {
+    def result = [:]
+    def context = SiteServices.createContext(appContext, request)
+    def studioConfigurationSB = context.applicationContext.get("studioConfiguration")
+    result.useBaseDomain = studioConfigurationSB.getProperty(STUDIO_COOKIE_USE_BASE_DOMAIN)
+    return result
+  }
 }

--- a/src/main/webapp/default-site/scripts/pages/entry.groovy
+++ b/src/main/webapp/default-site/scripts/pages/entry.groovy
@@ -58,11 +58,11 @@ try {
 }
 
 model.username = currentUser
-model.userEmail = profile.email 
+model.userEmail = profile.email
 model.userFirstName = profile.first_name
 model.userLastName =  profile.last_name
 model.authenticationType =  authenticatedUser?
         authenticatedUser.getAuthenticationType() as String : profile.authentication_type
 model.cookieDomain = StringEscapeUtils.escapeXml10(request.getServerName())
 model.passwordRequirementsRegex = passwordRequirementsRegex;
-model.envConfig = EnvironmentOverrides.getValuesForSite(applicationContext, request, response)
+model.envConfig = EnvironmentOverrides.getMinimalValuesForSite(applicationContext, request)

--- a/src/main/webapp/default-site/scripts/pages/preview.groovy
+++ b/src/main/webapp/default-site/scripts/pages/preview.groovy
@@ -26,7 +26,7 @@ def username = request.getSession().getValue("username");
 def context = SecurityServices.createContext(applicationContext, request, response);
 def profile = SecurityServices.getUserProfile(context, username);
 
-model.envConfig = EnvironmentOverrides.getValuesForSite(applicationContext, request, response)
+model.envConfig = EnvironmentOverrides.getMinimalValuesForSite(applicationContext, request)
 model.userEmail = profile.email
 model.userFirstName = profile.firstName
 model.userLastName =  profile.lastName


### PR DESCRIPTION
Roll back #2991 since getSiteValues is a little too aggressive in all that it does particularly for the entry page. Added a new method that does only what we needed. Should discuss if there's a better place to locate the new method or a better name for it.

craftercms/craftercms#5604
