### PR TITLE
Bugfix/5634

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/repository/blob/BlobAwareContentRepository.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/blob/BlobAwareContentRepository.java
@@ -26,6 +26,7 @@ import org.craftercms.commons.file.blob.exception.BlobStoreConfigurationMissingE
 import org.craftercms.core.service.Item;
 import org.craftercms.studio.api.v1.constant.GitRepositories;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
+import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepositoryCredentialsException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepositoryException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteUrlException;
@@ -717,13 +718,15 @@ public class BlobAwareContentRepository implements ContentRepository,
     }
 
     @Override
-    public void initialPublish(String siteId) {
+    public void initialPublish(String siteId) throws SiteNotFoundException {
         try {
             List<StudioBlobStore> blobStores = blobStoreResolver.getAll(siteId);
             for (StudioBlobStore blobStore : blobStores) {
                 blobStore.initialPublish(siteId);
             }
             localRepositoryV2.initialPublish(siteId);
+        } catch (SiteNotFoundException e) {
+            throw e;
         } catch (Exception e) {
             logger.error("Error performing initial publish for site {0}", e, siteId);
         }

--- a/src/test/java/org/craftercms/studio/impl/v2/repository/blob/BlobAwareContentRepositoryTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/repository/blob/BlobAwareContentRepositoryTest.java
@@ -151,7 +151,7 @@ public class BlobAwareContentRepositoryTest {
 
     @Test
     public void getContentSizeTest() {
-        assertEquals(proxy.getContentSize(SITE, ORIGINAL_PATH), SIZE, "original path should return the original size");
+        assertEquals(proxy.getContentSize(SITE, ORIGINAL_PATH), -1, "Blob content items should return -1");
     }
 
     @Test
@@ -381,6 +381,13 @@ public class BlobAwareContentRepositoryTest {
 
         verify(store).initialPublish(SITE);
         verify(localV2).initialPublish(SITE);
+    }
+
+    @Test(expectedExceptions=SiteNotFoundException.class)
+    public void blobAwareRepoBubblesUpSiteNotFoundExceptionTest() throws SiteNotFoundException {
+        String nonExistingSite = "nonExistingSite";
+        doThrow(SiteNotFoundException.class).when(localV2).initialPublish(nonExistingSite);
+        proxy.initialPublish("nonExistingSite");
     }
 
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5634

Making BlobAwareContentRepository bubble SiteNotFoundException up, so response code is the correct one when site does not exist