### PR TITLE
Bugfix/5639

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioUtils.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioUtils.java
@@ -17,6 +17,7 @@
 package org.craftercms.studio.api.v2.utils;
 
 import org.craftercms.commons.http.RequestContext;
+import org.craftercms.studio.api.v1.constant.StudioConstants;
 import org.craftercms.studio.api.v1.log.Logger;
 import org.craftercms.studio.api.v1.log.LoggerFactory;
 
@@ -63,5 +64,21 @@ public abstract class StudioUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Gets the top level folder where {@code path} is contained.
+     * The result will be a value from the list defined at StudioConstants.TOP_LEVEL_FOLDERS, if found, null otherwise.
+     *
+     * @param path the content path
+     * @return top level root path, if matched, or null otherwise
+     */
+    public static String getTopLevelFolder(final String path) {
+        return StudioConstants.TOP_LEVEL_FOLDERS.stream()
+                // Remove index file at the end of the path (to support /site/website/index.xml case) so we always get a folder path
+                .map(folder -> folder.replaceFirst(StudioConstants.FILE_SEPARATOR + StudioConstants.INDEX_FILE + "$", ""))
+                .filter(path::startsWith)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
@@ -83,12 +83,11 @@ public class ClipboardServiceInternalImpl implements ClipboardServiceInternal, A
 
     public List<String> pasteItems(String siteId, Operation operation, String targetPath, PasteItem item)
             throws ServiceLayerException, UserNotFoundException {
-        logger.trace("Pasting content from '{}' to '{}' for site '{}'", item.getPath(), targetPath, siteId);
         validatePasteItemsAction(siteId, item.getPath(), targetPath);
         var pastedItems = new LinkedList<String>();
         pasteItemsInternal(siteId, operation, targetPath, List.of(item), pastedItems);
-        logger.trace("Content pasted from '{}' to '{}' for site '{}'. '{}' items were pasted.",
-                item.getPath(), targetPath, siteId, pastedItems.size());
+        logger.trace("'{}' items pasted in site '{}' from '{}' to '{}'",
+                pastedItems.size(), siteId, item.getPath(), targetPath);
         return pastedItems;
     }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
@@ -21,13 +21,13 @@ import org.craftercms.studio.api.v1.log.Logger;
 import org.craftercms.studio.api.v1.log.LoggerFactory;
 import org.craftercms.studio.api.v1.service.content.ContentService;
 import org.craftercms.studio.api.v1.service.workflow.WorkflowService;
+import org.craftercms.studio.api.v1.to.ContentItemTO;
+import org.craftercms.studio.api.v2.exception.InvalidParametersException;
 import org.craftercms.studio.api.v2.service.clipboard.internal.ClipboardServiceInternal;
 import org.craftercms.studio.model.clipboard.Operation;
 import org.craftercms.studio.model.clipboard.PasteItem;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -54,6 +54,10 @@ public class ClipboardServiceInternalImpl implements ClipboardServiceInternal, A
 
     public List<String> pasteItems(String siteId, Operation operation, String targetPath, PasteItem item)
             throws ServiceLayerException, UserNotFoundException {
+        ContentItemTO targetContentItem = contentService.getContentItem(siteId, targetPath);
+        if (!targetContentItem.isPage() && !targetContentItem.isFolder()) {
+            throw new InvalidParametersException("Only pages and folders can contain children");
+        }
         var pastedItems = new LinkedList<String>();
         pasteItemsInternal(siteId, operation, targetPath, List.of(item), pastedItems);
         return pastedItems;

--- a/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImpl.java
@@ -15,6 +15,7 @@
  */
 package org.craftercms.studio.impl.v2.service.clipboard.internal;
 
+import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
 import org.craftercms.studio.api.v1.log.Logger;
@@ -24,6 +25,7 @@ import org.craftercms.studio.api.v1.service.workflow.WorkflowService;
 import org.craftercms.studio.api.v1.to.ContentItemTO;
 import org.craftercms.studio.api.v2.exception.InvalidParametersException;
 import org.craftercms.studio.api.v2.service.clipboard.internal.ClipboardServiceInternal;
+import org.craftercms.studio.api.v2.utils.StudioUtils;
 import org.craftercms.studio.model.clipboard.Operation;
 import org.craftercms.studio.model.clipboard.PasteItem;
 import org.springframework.context.ApplicationContext;
@@ -31,6 +33,7 @@ import org.springframework.context.ApplicationContextAware;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.io.FilenameUtils.getFullPathNoEndSeparator;
@@ -52,12 +55,34 @@ public class ClipboardServiceInternalImpl implements ClipboardServiceInternal, A
     protected WorkflowService workflowService;
     protected ApplicationContext applicationContext;
 
-    public List<String> pasteItems(String siteId, Operation operation, String targetPath, PasteItem item)
-            throws ServiceLayerException, UserNotFoundException {
+    protected void validatePasteItemsAction(final String siteId, final String sourcePath, final String targetPath)
+            throws InvalidParametersException, ContentNotFoundException {
         ContentItemTO targetContentItem = contentService.getContentItem(siteId, targetPath);
+        if (targetContentItem.isDeleted()) {
+            throw new ContentNotFoundException(targetPath, siteId, String.format("Target path '%s' does not exist. " +
+                    "Unable to perform paste operation", targetPath));
+        }
         if (!targetContentItem.isPage() && !targetContentItem.isFolder()) {
             throw new InvalidParametersException("Only pages and folders can contain children");
         }
+        if (!contentService.contentExists(siteId, sourcePath)) {
+            throw new ContentNotFoundException(sourcePath, siteId, String.format("No content found at path '%s' " +
+                    "Unable to perform paste operation", sourcePath));
+        }
+        String sourceTopLevel = StudioUtils.getTopLevelFolder(sourcePath);
+        String targetTopLevel = StudioUtils.getTopLevelFolder(targetPath);
+
+        if (!Objects.equals(sourceTopLevel, targetTopLevel)) {
+            throw new InvalidParametersException(String.format("Cannot perform paste operation " +
+                            "from '%s' (%s) into '%s' (%s) for site '%s'. " +
+                            "Pasting across top level folders is not supported.",
+                    sourcePath, sourceTopLevel, targetPath, targetTopLevel, siteId));
+        }
+    }
+
+    public List<String> pasteItems(String siteId, Operation operation, String targetPath, PasteItem item)
+            throws ServiceLayerException, UserNotFoundException {
+        validatePasteItemsAction(siteId, item.getPath(), targetPath);
         var pastedItems = new LinkedList<String>();
         pasteItemsInternal(siteId, operation, targetPath, List.of(item), pastedItems);
         return pastedItems;

--- a/src/test/java/org/craftercms/studio/api/v2/utils/StudioUtilsTest.java
+++ b/src/test/java/org/craftercms/studio/api/v2/utils/StudioUtilsTest.java
@@ -1,0 +1,37 @@
+package org.craftercms.studio.api.v2.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class StudioUtilsTest {
+
+    @Test
+    public void getTopLevelFolderTest() {
+        assertEquals("/site/website", StudioUtils.getTopLevelFolder("/site/website/articles/2022/test/index.xml"));
+        assertEquals("/site/website", StudioUtils.getTopLevelFolder("/site/website/index.xml"));
+
+        assertEquals("/site/components", StudioUtils.getTopLevelFolder("/site/components/articles/article1.xml"));
+        assertEquals("/site/components", StudioUtils.getTopLevelFolder("/site/components/articles/2022/test/index.xml"));
+
+        assertEquals("/site/taxonomy", StudioUtils.getTopLevelFolder("/site/taxonomy/categories"));
+        assertEquals("/site/taxonomy", StudioUtils.getTopLevelFolder("/site/taxonomy/categories/tax1.xml"));
+
+        assertEquals("/static-assets", StudioUtils.getTopLevelFolder("/static-assets/images/logos/fb.png"));
+        assertEquals("/static-assets", StudioUtils.getTopLevelFolder("/static-assets/js/head/"));
+
+        assertEquals("/templates", StudioUtils.getTopLevelFolder("/templates/web/sidebar/widgets.ftl"));
+        assertEquals("/templates", StudioUtils.getTopLevelFolder("/templates/web/blog/"));
+
+        assertEquals("/scripts", StudioUtils.getTopLevelFolder("/scripts/rest/search"));
+        assertEquals("/scripts", StudioUtils.getTopLevelFolder("/scripts/filters/site.groovy"));
+
+        assertEquals("/sources", StudioUtils.getTopLevelFolder("/sources/utils/Util.groovy"));
+        assertEquals("/sources", StudioUtils.getTopLevelFolder("/sources/utils/"));
+
+        assertNull(StudioUtils.getTopLevelFolder("/custom/path"));
+        assertNull(StudioUtils.getTopLevelFolder("/"));
+        assertNull(StudioUtils.getTopLevelFolder("/my-documents/private/report.doc"));
+    }
+}

--- a/src/test/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImplTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImplTest.java
@@ -1,0 +1,200 @@
+package org.craftercms.studio.impl.v2.service.clipboard.internal;
+
+import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
+import org.craftercms.studio.api.v1.service.content.ContentService;
+import org.craftercms.studio.api.v1.to.ContentItemTO;
+import org.craftercms.studio.api.v2.exception.InvalidParametersException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClipboardServiceInternalImplTest {
+
+    private static final String SITE_ID = "mySite";
+
+    @Mock
+    private ContentService contentService;
+
+    @InjectMocks
+    private ClipboardServiceInternalImpl service;
+
+    @Before
+    public void setUp() {
+        for (String pagePath : getPagePaths()) {
+            when(contentService.getContentItem(SITE_ID, pagePath))
+                    .thenReturn(createTestContentItem(false, true));
+        }
+        for (String folderPath : getFolderPaths()) {
+            when(contentService.getContentItem(SITE_ID, folderPath))
+                    .thenReturn(createTestContentItem(true, false));
+        }
+        for (String nonFolderPath : getNonFolderPaths()) {
+            when(contentService.getContentItem(SITE_ID, nonFolderPath))
+                    .thenReturn(createTestContentItem(false, false));
+        }
+
+        for (String existingPath : getExistingPaths()) {
+            when(contentService.contentExists(SITE_ID, existingPath)).thenReturn(true);
+        }
+    }
+
+    private String[] getPagePaths() {
+        return new String[]{
+                "/site/website/health/index.xml"
+        };
+    }
+
+    private String[] getExistingPaths() {
+        return new String[]{
+                "/site/website/style/index.xml",
+                "/site/website/news",
+                "/static-assets/images/screenshot.png",
+                "/site/components/header/default.xml",
+                "/templates/web/layout/main.ftl",
+                "/scripts/rest/search/documents.get.groovy",
+                "/sources/folder/script.groovy",
+                "/site/taxonomy/categories.xml",
+                "/custom/folder/item.xls"
+        };
+    }
+
+    private String[] getFolderPaths() {
+        return new String[]{
+                "/site/website/articles",
+                "/site/components/headers",
+                "/static-assets/screenshots",
+                "/templates/web/blog",
+                "/scripts/rest/documents/search",
+                "/sources/classes/folder",
+                "/site/taxonomy/categories",
+                "/custom/old",
+                "/reports/folder"
+        };
+    }
+
+    private String[] getNonFolderPaths() {
+        return new String[]{
+                "/templates/web/layout.ftl",
+                "/static-assets/screenshot.png"};
+    }
+
+    private ContentItemTO createTestContentItem(boolean isFolder, boolean isPage) {
+        ContentItemTO item = new ContentItemTO();
+        item.setFolder(isFolder);
+        item.setPage(isPage);
+        return item;
+    }
+
+    @Test
+    public void allowPastingFolderIntoPageTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/website/news", "/site/website/health/index.xml");
+    }
+
+    @Test
+    public void allowPastingPageIntoFolderTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/site/website/articles");
+    }
+
+    @Test
+    public void allowPastingFolderIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/website/news", "/site/website/articles");
+    }
+
+    @Test
+    public void allowPastingPageIntoPageTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/site/website/health/index.xml");
+    }
+
+    @Test
+    public void allowPastingAssetIntoFolderTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshots");
+    }
+
+    @Test
+    public void allowPastingComponentIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/components/header/default.xml", "/site/components/headers");
+    }
+
+    @Test
+    public void allowPastingTemplateIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/blog");
+    }
+
+    @Test
+    public void allowPastingScriptIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/scripts/rest/search/documents.get.groovy", "/scripts/rest/documents/search");
+    }
+
+    @Test
+    public void allowPastingSourcesFileIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/sources/folder/script.groovy", "/sources/classes/folder");
+    }
+
+    @Test
+    public void allowPastingTaxonomyIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/taxonomy/categories.xml", "/site/taxonomy/categories");
+    }
+
+    @Test
+    public void allowTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/reports/folder");
+    }
+
+    @Test
+    public void allowPastingCustomPathItemIntoFolderTest() throws
+            ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/custom/old");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingPageIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/static-assets/screenshots");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingComponentIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/site/components/header/default.xml", "/static-assets/screenshots");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingAssetIntoAssetTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshot.png");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingTemplateIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/static-assets/screenshots");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingTemplateIntoTemplateTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/layout.ftl");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingScriptIntoTaxonomiesTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/scripts/rest/search/documents.get.groovy", "/site/taxonomy/categories");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingCustomPathItemIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/static-assets/screenshots");
+    }
+
+    @Test(expected = InvalidParametersException.class)
+    public void preventPastingTemplateIntoCustomPathTest() throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/custom/old");
+    }
+}

--- a/src/test/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImplTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/service/clipboard/internal/ClipboardServiceInternalImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -92,109 +93,160 @@ public class ClipboardServiceInternalImplTest {
     }
 
     @Test
-    public void allowPastingFolderIntoPageTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/website/news", "/site/website/health/index.xml");
+    public void allowPastingFolderIntoPageTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/website/news", "/site/website/health/index.xml"));
     }
 
     @Test
-    public void allowPastingPageIntoFolderTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/site/website/articles");
+    public void allowPastingPageIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/website/style/index.xml", "/site/website/articles"));
     }
 
     @Test
-    public void allowPastingFolderIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/website/news", "/site/website/articles");
+    public void allowPastingFolderIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/website/news", "/site/website/articles"));
     }
 
     @Test
-    public void allowPastingPageIntoPageTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/site/website/health/index.xml");
+    public void allowPastingPageIntoPageTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/website/style/index.xml", "/site/website/health/index.xml"));
     }
 
     @Test
-    public void allowPastingAssetIntoFolderTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshots");
+    public void allowPastingAssetIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshots"));
     }
 
     @Test
-    public void allowPastingComponentIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/components/header/default.xml", "/site/components/headers");
+    public void allowPastingComponentIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/components/header/default.xml", "/site/components/headers"));
     }
 
     @Test
-    public void allowPastingTemplateIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/blog");
+    public void allowPastingTemplateIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/blog"));
     }
 
     @Test
-    public void allowPastingScriptIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/scripts/rest/search/documents.get.groovy", "/scripts/rest/documents/search");
+    public void allowPastingScriptIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID,
+                                "/scripts/rest/search/documents.get.groovy",
+                                "/scripts/rest/documents/search"));
     }
 
     @Test
-    public void allowPastingSourcesFileIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/sources/folder/script.groovy", "/sources/classes/folder");
+    public void allowPastingSourcesFileIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/sources/folder/script.groovy", "/sources/classes/folder"));
     }
 
     @Test
-    public void allowPastingTaxonomyIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/taxonomy/categories.xml", "/site/taxonomy/categories");
+    public void allowPastingTaxonomyIntoFolderTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/site/taxonomy/categories.xml", "/site/taxonomy/categories"));
     }
 
     @Test
-    public void allowTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/reports/folder");
+    public void allowTest() {
+        assertDoesNotThrow(
+                () ->
+                        service.validatePasteItemsAction(
+                                SITE_ID, "/custom/folder/item.xls", "/reports/folder"));
     }
 
     @Test
-    public void allowPastingCustomPathItemIntoFolderTest() throws
-            ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/custom/old");
+    public void allowPastingCustomPathItemIntoFolderTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        assertDoesNotThrow(
+                () -> service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/custom/old"));
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingPageIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/website/style/index.xml", "/static-assets/screenshots");
+    public void preventPastingPageIntoStaticAssetsTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/site/website/style/index.xml", "/static-assets/screenshots");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingComponentIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/site/components/header/default.xml", "/static-assets/screenshots");
+    public void preventPastingComponentIntoStaticAssetsTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/site/components/header/default.xml", "/static-assets/screenshots");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingAssetIntoAssetTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshot.png");
+    public void preventPastingAssetIntoAssetTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/static-assets/images/screenshot.png", "/static-assets/screenshot.png");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingTemplateIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/static-assets/screenshots");
+    public void preventPastingTemplateIntoStaticAssetsTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/templates/web/layout/main.ftl", "/static-assets/screenshots");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingTemplateIntoTemplateTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/layout.ftl");
+    public void preventPastingTemplateIntoTemplateTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/templates/web/layout/main.ftl", "/templates/web/layout.ftl");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingScriptIntoTaxonomiesTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/scripts/rest/search/documents.get.groovy", "/site/taxonomy/categories");
+    public void preventPastingScriptIntoTaxonomiesTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/scripts/rest/search/documents.get.groovy", "/site/taxonomy/categories");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingCustomPathItemIntoStaticAssetsTest() throws ContentNotFoundException, InvalidParametersException {
-        service.validatePasteItemsAction(SITE_ID, "/custom/folder/item.xls", "/static-assets/screenshots");
+    public void preventPastingCustomPathItemIntoStaticAssetsTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(
+                SITE_ID, "/custom/folder/item.xls", "/static-assets/screenshots");
     }
 
     @Test(expected = InvalidParametersException.class)
-    public void preventPastingTemplateIntoCustomPathTest() throws ContentNotFoundException, InvalidParametersException {
+    public void preventPastingTemplateIntoCustomPathTest()
+            throws ContentNotFoundException, InvalidParametersException {
         service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/main.ftl", "/custom/old");
+    }
+
+    @Test(expected = ContentNotFoundException.class)
+    public void preventPastingNonExistingContentTest()
+            throws ContentNotFoundException, InvalidParametersException {
+        service.validatePasteItemsAction(SITE_ID, "/templates/web/layout/unexistent.ftl", "/templates/web/blog");
     }
 }


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5639
Preventing content from being pasted across root folders (e.g.: from scripts into templates)
Handle cases where either source or target content does not exist
Adding unit tests