### PR TITLE
Bugfix/5656 3.1.x

### DIFF
--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -161,7 +161,8 @@ CREATE TABLE IF NOT EXISTS `audit_parameters` (
   PRIMARY KEY (`id`),
   KEY `audit_parameters_audit_id_idx` (`audit_id`),
   KEY `audit_parameters_target_id_idx` (`target_id`),
-  KEY `audit_parameters_target_value_idx` (`target_value`)
+  KEY `audit_parameters_target_value_idx` (`target_value`),
+  CONSTRAINT `audit_parameters_ix_audit_id` FOREIGN KEY (`audit_id`) REFERENCES `audit` (`id`) ON DELETE CASCADE
 )
   ENGINE = InnoDB
   DEFAULT CHARSET = utf8

--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -124,7 +124,7 @@ CREATE TABLE _meta (
   PRIMARY KEY (`version`)
 ) ;
 
-INSERT INTO _meta (version, studio_id) VALUES ('3.1.24', UUID()) ;
+INSERT INTO _meta (version, studio_id) VALUES ('3.1.24.1', UUID()) ;
 
 CREATE TABLE IF NOT EXISTS `audit` (
   `id`                        BIGINT(20)    NOT NULL AUTO_INCREMENT,

--- a/src/main/resources/crafter/studio/database/upgrade-3.1.24-to-3.1.24.1.sql
+++ b/src/main/resources/crafter/studio/database/upgrade-3.1.24-to-3.1.24.1.sql
@@ -15,9 +15,8 @@
  */
 
  -- Delete orphan audit_parameters records from deleted sites
-DELETE ap.*
-FROM audit_parameters ap
-WHERE audit_id NOT IN (SELECT id FROM audit a) ;
+DELETE FROM audit_parameters
+WHERE audit_id NOT IN (SELECT id FROM audit) ;
 
 -- Add missing FK audit_parameters -> audit
 ALTER TABLE `audit_parameters`

--- a/src/main/resources/crafter/studio/database/upgrade-3.1.24-to-3.1.24.1.sql
+++ b/src/main/resources/crafter/studio/database/upgrade-3.1.24-to-3.1.24.1.sql
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ -- Delete orphan audit_parameters records from deleted sites
+DELETE ap.*
+FROM audit_parameters ap
+WHERE audit_id NOT IN (SELECT id FROM audit a) ;
+
+-- Add missing FK audit_parameters -> audit
+ALTER TABLE `audit_parameters`
+ADD CONSTRAINT `audit_parameters_ix_audit_id`
+	FOREIGN KEY IF NOT EXISTS (`audit_id`) REFERENCES `audit`(`id`)
+ON DELETE CASCADE ;
+
+UPDATE _meta SET version = '3.1.24.1' ;

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -991,6 +991,11 @@ pipelines:
                 dest: /configuration/samples/sample-notification-config.xml
           commitDetails: Update sample file for notifications
         - type: dbVersionUpgrader
+    - currentVersion: 3.1.24
+      nextVersion: 3.1.24.1
+      operations:
+        - type: dbScriptUpgrader
+          filename: upgrade-3.1.24-to-3.1.24.1.sql
 
   # Pipeline to upgrade site repositories
   site:


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5656
Adding missing FK constraint to createDDL.sql script to audit_parameters table to prevent phantom records after site deletion