### PR TITLE
Upgrade Manager: Preventing NPE for site updates when includedPaths pattern has no match

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/AbstractContentUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/AbstractContentUpgradeOperation.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.configuration2.HierarchicalConfiguration;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.lang.RegexUtils;
 import org.craftercms.commons.upgrade.exception.UpgradeException;
 import org.craftercms.studio.api.v1.log.Logger;
@@ -77,7 +78,7 @@ public abstract class AbstractContentUpgradeOperation extends AbstractUpgradeOpe
         try {
             List<Path> includedPaths = findIncludedPaths(context);
             // This is required to support upgrades in config pipelines
-            if (isEmpty(includedPaths)) {
+            if (isEmpty(includedPaths) && StringUtils.isNotEmpty(context.getCurrentConfigPath())) {
                 Path repo = context.getRepositoryPath(); //TODO: Check if parent is needed
                 includedPaths = singletonList(repo.resolve(removeStart(context.getCurrentConfigPath(), //TODO: Check if path is ok
                         File.separator)));


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5672
Upgrade Manager: Preventing NPE for site updates when includedPaths pattern has no match