### PR TITLE
    Prevent requests for content duplicate, paste or delete to continue when containing invalid parameters in request body

### DIFF
--- a/src/main/java/org/craftercms/studio/model/rest/clipboard/DuplicateRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/clipboard/DuplicateRequest.java
@@ -25,7 +25,6 @@ import javax.validation.constraints.NotEmpty;
  * @author joseross
  * @since 3.2
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class DuplicateRequest {
 
     /**

--- a/src/main/java/org/craftercms/studio/model/rest/clipboard/PasteRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/clipboard/PasteRequest.java
@@ -29,7 +29,6 @@ import javax.validation.constraints.NotNull;
  * @author joseross
  * @since 3.2
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class PasteRequest {
 
     /**

--- a/src/main/java/org/craftercms/studio/model/rest/content/DeleteRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/content/DeleteRequestBody.java
@@ -22,7 +22,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class DeleteRequestBody {
 
     @NotEmpty


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5669
Prevent requests for content duplicate, paste or delete to continue when containing invalid parameters in request body
