### PR TITLE
[bugfix] Added \s regex to target path pattern in BPs policy configuration

### DIFF
--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-policy-config.xml
@@ -19,7 +19,7 @@
         <target-path-pattern>/static-assets/.*</target-path-pattern>
         <permitted>
             <path>
-                <source-regex>[\(\)]</source-regex>
+                <source-regex>[\(\)\s]</source-regex>
                 <target-regex>-</target-regex>
             </path>
         </permitted>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-policy-config.xml
@@ -19,7 +19,7 @@
         <target-path-pattern>/static-assets/.*</target-path-pattern>
         <permitted>
             <path>
-                <source-regex>[\(\)]</source-regex>
+                <source-regex>[\(\)\s]</source-regex>
                 <target-regex>-</target-regex>
             </path>
         </permitted>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-policy-config.xml
@@ -19,7 +19,7 @@
         <target-path-pattern>/static-assets/.*</target-path-pattern>
         <permitted>
             <path>
-                <source-regex>[\(\)]</source-regex>
+                <source-regex>[\(\)\s]</source-regex>
                 <target-regex>-</target-regex>
             </path>
         </permitted>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-policy-config.xml
@@ -19,7 +19,7 @@
         <target-path-pattern>/static-assets/.*</target-path-pattern>
         <permitted>
             <path>
-                <source-regex>[\(\)]</source-regex>
+                <source-regex>[\(\)\s]</source-regex>
                 <target-regex>-</target-regex>
             </path>
         </permitted>


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR

Added `\s` space regex to Editorial, Headless, Empty and Blog blueprint's site-policy-configuration based on ticket 5777: 

https://github.com/craftercms/craftercms/issues/5777
