### PR TITLE
Added lowercase target-regex to policy configuration of Editorial, Empty, Blog, Store BPs

### DIFF
--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-policy-config.xml
@@ -20,7 +20,7 @@
         <permitted>
             <path>
                 <source-regex>[\(\)\s]</source-regex>
-                <target-regex>-</target-regex>
+                <target-regex caseTransform="lowercase">-</target-regex>
             </path>
         </permitted>
     </statement>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-policy-config.xml
@@ -20,7 +20,7 @@
         <permitted>
             <path>
                 <source-regex>[\(\)\s]</source-regex>
-                <target-regex>-</target-regex>
+                <target-regex caseTransform="lowercase">-</target-regex>
             </path>
         </permitted>
     </statement>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-policy-config.xml
@@ -20,7 +20,7 @@
         <permitted>
             <path>
                 <source-regex>[\(\)\s]</source-regex>
-                <target-regex>-</target-regex>
+                <target-regex caseTransform="lowercase">-</target-regex>
             </path>
         </permitted>
     </statement>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-policy-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-policy-config.xml
@@ -20,7 +20,7 @@
         <permitted>
             <path>
                 <source-regex>[\(\)\s]</source-regex>
-                <target-regex>-</target-regex>
+                <target-regex caseTransform="lowercase">-</target-regex>
             </path>
         </permitted>
     </statement>


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR

Added lowercase target-regex statement to policy configuration of basic Crafter BPs: Editorial, Empty, Headless Blog and Headless Store
