### PR TITLE
Accept null keywords while calling marketplace search API

### DIFF
--- a/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/MarketplaceController.java
@@ -70,7 +70,7 @@ public class MarketplaceController {
     @ValidateParams
     @GetMapping("/search")
     public ResponseBody searchPlugins(@RequestParam(required = false) String type,
-                                      @EsapiValidatedParam(type = SEARCH_KEYWORDS, notBlank = false, notEmpty = false)
+                                      @EsapiValidatedParam(type = SEARCH_KEYWORDS, notBlank = false, notEmpty = false, notNull = false)
                                       @RequestParam(required = false) String keywords,
                                       @RequestParam(required = false, defaultValue = "false") boolean showIncompatible,
                                       @RequestParam(required = false, defaultValue = "0") long offset,


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
A small fix for https://github.com/craftersoftware/craftercms/issues/410
In the create project screen, we call marketplace API without the `keywords` option. A `null` value should be valid for `keywords`.