### PR TITLE
Correct format while update xml file version

### DIFF
--- a/src/main/resources/crafter/studio/upgrade/formatter.xslt
+++ b/src/main/resources/crafter/studio/upgrade/formatter.xslt
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<xsl:stylesheet
+        version="2.0"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+>
+    <!-- to keep the right formatting, use default indent which is 4 spaces -->
+    <xsl:output method="xml" encoding="UTF-8" indent="yes" />
+    <xsl:strip-space elements="*"/>
+
+    <!-- copy all elements -->
+    <xsl:template match="node() | @*">
+        <!-- insert a line break before root element-->
+        <xsl:if test="not(ancestor::*)">
+            <xsl:text>&#10;</xsl:text>
+        </xsl:if>
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/5762

* `XMLWriter` updates configuration files to have 2 spaces tab and there are trailing spaces on each line of the XML document. This does not match the default format from the  blueprints (which has 4 spaces tab): 

![additional_trailing_space](https://user-images.githubusercontent.com/2996543/211739716-e9b1aa62-001f-420e-8bcd-ab6a22507fd6.png)

* This PR corrects the format to use 4 spaces that align with the current blueprints format and also makes sure there are so trailing spaces on the new XML.

To achieve that, I'm using `TransformerFactory` with the Xalan factory class with the transformer reading format of an XSLT file which we can modify when needed. (By default, the factory is using `net.sf.saxon` which produces 3 spaces tabbing and won't align with the blueprints):

![2023-01-11_14-13](https://user-images.githubusercontent.com/2996543/211741322-78c855e5-27fc-40d9-a0c3-ae6a90381f90.png)
