### PR TITLE
Validate asset path before writing asset content

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
@@ -85,6 +85,14 @@ public interface ContentService {
      */
     String getContentAsString(String site, String path);
 
+
+    /**
+     * Check if path is a correct location to write asset content
+     * @param path to write asset
+     * @throws ServiceLayerException if path is not permitted
+     */
+    void checkWriteAssetPath(String path) throws ServiceLayerException;
+
     /**
      * get content as string from repository
      *

--- a/src/main/java/org/craftercms/studio/impl/v1/service/asset/processing/AssetProcessingServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/asset/processing/AssetProcessingServiceImpl.java
@@ -87,13 +87,15 @@ public class AssetProcessingServiceImpl implements AssetProcessingService {
     @Override
     public Map<String, Object> processAsset(String site, String folder, String assetName, InputStream in, String isImage,
                                             String allowedWidth, String allowedHeight, String allowLessSize, String draft,
-                                            String unlock, String systemAsset){
+                                            String unlock, String systemAsset) {
         String repoPath = UrlUtils.concat(folder, assetName);
         InputStream configIn;
 
         // TODO: SJ: Refactor with guard statements to reduce nesting and enhance readability
 
         try {
+            contentService.checkWriteAssetPath(folder);
+
             try {
                 configIn = contentService.getContent(site, configPath);
             } catch (ContentNotFoundException e) {
@@ -166,7 +168,7 @@ public class AssetProcessingServiceImpl implements AssetProcessingService {
             logger.error("Failed to process asset '{}' in site '{}'", assetName, site, e);
 
             Map<String, Object> result = new HashMap<>();
-            result.put("success", true);
+            result.put("success", false);
             result.put("message", e.getMessage());
             result.put("error", e);
 

--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -194,6 +194,14 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
 
     @Override
     @Valid
+    public void checkWriteAssetPath(@ValidateStringParam String path) throws ServiceLayerException {
+        if (path.startsWith(SLASH_SITE)) {
+            throw new ServiceLayerException(format("Unable to write asset content to the path '%s'.", path));
+        }
+    }
+
+    @Override
+    @Valid
     public String getContentAsString(@ValidateStringParam String site,
                                      @ValidateSecurePathParam String path,
                                      @ValidateStringParam String encoding)  {
@@ -542,7 +550,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
         } catch (Exception e) {
             logger.error("Failed to process content at site '{}' path '{}'", site, path, e);
             Map<String, Object> toRet = new HashMap<>();
-            toRet.put("success", true);
+            toRet.put("success", false);
             toRet.put("message", e.getMessage());
             toRet.put("error", e);
             return toRet;

--- a/src/main/webapp/default-site/scripts/rest/api/1/content/write-content.post.groovy
+++ b/src/main/webapp/default-site/scripts/rest/api/1/content/write-content.post.groovy
@@ -83,12 +83,18 @@ if(ServletFileUpload.isMultipartContent(request)) {
             }
             contentType = item.getContentType()
             try {
-                result = ContentServices.writeContentAsset(context, site, path, fileName, stream,
+                def writeAssetRes = ContentServices.writeContentAsset(context, site, path, fileName, stream,
                         isImage, allowedWidth, allowedHeight, allowLessSize, draft, unlock, systemAsset)
-                if (result.message.isDeleted()) {
+                if (!writeAssetRes.success) {
+                    response.setStatus(500)
+                    result.success = false
+                    result.message = writeAssetRes.message ?: "Failed to write asset"
+                } else if (writeAssetRes.success && writeAssetRes.message.isDeleted()) {
                     response.setStatus(500)
                     result.success = false
                     result.message = "Failed to write asset"
+                } else {
+                    result = writeAssetRes
                 }
             } catch (ServiceLayerException e) {
                 response.setStatus(500)


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/5862

Sample of response in the case of exception:

```
POST /studio/api/1/services/api/1/content/write-content.json
Status Code: 500 
{
    "success": false,
    "message": "Unable to write asset content to the path '/site/components/headers'."
}
```

* Check if a path is writeable for asset content. Assets should not be written to `/site` or any nested folders.
* Update try/catch response for method `writeContentAsset`: 
  * If there are exceptions, the `success` property should be `false`
  * Send the error message to the client if possible.