### PR TITLE
Correct socket event on writeContent after persisting content

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
@@ -136,6 +136,13 @@ public interface ContentService {
     boolean writeContent(String site, String path, InputStream content) throws ServiceLayerException;
 
     /**
+     * Notify when there is a content update
+     * @param site site name
+     * @param path path name
+     */
+    void notifyContentEvent(String site, String path);
+
+    /**
      * create a folder
      *
      * @param site - the project ID

--- a/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
@@ -217,6 +217,7 @@ public class AssetDmContentProcessor extends FormDmContentProcessor {
 
             // Item
             itemServiceInternal.persistItemAfterWrite(site, relativePath, user, commitId, unlock);
+            contentService.notifyContentEvent(site, relativePath);
         }
 
         if (unlock) {

--- a/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/FormDmContentProcessor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/FormDmContentProcessor.java
@@ -202,6 +202,7 @@ public class FormDmContentProcessor extends PathMatchProcessor implements DmCont
                         ContentUtils.getParentUrl(itemPath.replace(FILE_SEPARATOR + INDEX_FILE, ""));
                 Item parent = itemServiceInternal.getItem(site, parentItemPath, true);
                 itemServiceInternal.persistItemAfterCreate(site, itemPath, user, commitId, unlock, parent.getId());
+                contentService.notifyContentEvent(site, itemPath);
             } catch (Exception e) {
                 logger.error("Failed to create a new file in site '{}' name '{}'", site, fileName, e);
             } finally {
@@ -258,6 +259,7 @@ public class FormDmContentProcessor extends PathMatchProcessor implements DmCont
             // Item
             // TODO: get local code with API 2
             itemServiceInternal.persistItemAfterWrite(site, path, user, commitId, unlock);
+            contentService.notifyContentEvent(site, path);
         }
 
         // unlock the content upon save if the flag is true

--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -577,10 +577,20 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             itemServiceInternal.updateCommitId(site, path, commitId);
             contentRepository.insertGitLog(site, commitId, 1, 1);
             siteService.updateLastCommitId(site, commitId);
-            applicationContext.publishEvent(new ContentEvent(securityService.getAuthentication(), site, path));
         }
 
         return result;
+    }
+
+    /**
+     * Notify when there is a content update
+     * @param site site name
+     * @param path path name
+     */
+    @Override
+    @Valid
+    public void notifyContentEvent(@ValidateStringParam String site, @ValidateSecurePathParam String path) {
+        applicationContext.publishEvent(new ContentEvent(securityService.getAuthentication(), site, path));
     }
 
     @Override

--- a/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/configuration/ConfigurationServiceImpl.java
@@ -452,6 +452,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, Applicati
         try {
             itemServiceInternal.persistItemAfterWrite(siteId, configPath, currentUser,
                     contentRepository.getRepoLastCommitId(siteId), true);
+            contentService.notifyContentEvent(siteId, configPath);
         } catch (XmlFileParseException e) {
             logger.error("Failed to parse updated XML file at site '{}', path '{}'", siteId, configPath, e);
         }
@@ -538,6 +539,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, Applicati
                 String currentUser = securityService.getCurrentUser();
                 itemServiceInternal.persistItemAfterWrite(siteId, configPath, currentUser,
                         contentRepository.getRepoLastCommitId(siteId), true);
+                contentService.notifyContentEvent(siteId, configPath);
                 generateAuditLog(siteId, configPath, currentUser);
                 dependencyService.upsertDependencies(siteId, configPath);
             } else {
@@ -611,6 +613,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, Applicati
     public void writeGlobalConfiguration(@ProtectedResourceId(PATH_RESOURCE_ID) String path, InputStream content)
             throws ServiceLayerException {
         contentService.writeContent(EMPTY, path, validate(content, path));
+        contentService.notifyContentEvent(EMPTY, path);
         String currentUser = securityService.getCurrentUser();
         generateAuditLog(studioConfiguration.getProperty(CONFIGURATION_GLOBAL_SYSTEM_SITE), path, currentUser);
         invalidateCache(path);


### PR DESCRIPTION
### Ticket reference or full description of what's in the PR
https://github.com/craftercms/craftercms/issues/5853

`writeContent` method is incorrectly sent ContentEvent right after it is written to the Git repo. We should only send notification when the item is persisted (write to DB)