### PR TITLE
Prevent updating commit id when no change. Remove 'getSameCommitItems' for bulk publish

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
@@ -467,14 +467,6 @@ public interface ItemDAO {
                                         @Param(IN_PROGRESS_MASK) long inProgressMask);
 
     /**
-     * Get items edited on same commit id for given item
-     * @param siteId site identifier
-     * @param path path of content item
-     * @return list of items paths
-     */
-    List<String> getSameCommitItems(@Param(SITE_ID) String siteId, @Param(PATH) String path);
-
-    /**
      * Update last published date for item
      * @param siteId site identifier
      * @param path path of the item

--- a/src/main/java/org/craftercms/studio/api/v2/service/item/internal/ItemServiceInternal.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/item/internal/ItemServiceInternal.java
@@ -494,14 +494,6 @@ public interface ItemServiceInternal {
     List<String> getChangeSetForSubtree(String siteId, String path);
 
     /**
-     * Get items edited on same commit id for given item
-     * @param siteId site identifier
-     * @param path path of content item
-     * @return list of items paths
-     */
-    List<String> getSameCommitItems(String siteId, String path);
-
-    /**
      * Update last published date for item
      * @param siteId site identifier
      * @param path path of the item

--- a/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
@@ -170,11 +170,7 @@ public class AssetDmContentProcessor extends FormDmContentProcessor {
                 }
                 // Item
                 // TODO: get local code with API 2
-                String commitId = result.getCommitId();
-                if (StringUtils.isEmpty(commitId)) {
-                    commitId = contentRepository.getRepoLastCommitId(site);
-                }
-                itemServiceInternal.persistItemAfterWrite(site, contentPath, user, commitId, unlock);
+                itemServiceInternal.persistItemAfterWrite(site, contentPath, user, result.getCommitId(), unlock);
                 assetInfo.setFileExtension(ext);
                 return assetInfo;
             } else {

--- a/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DmPublishServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/deployment/DmPublishServiceImpl.java
@@ -139,14 +139,11 @@ public class DmPublishServiceImpl extends AbstractRegistrableService implements 
             logger.debug("Process bulk publish dependencies in site '{}' path '{}'", site, childPath);
             if (processedPaths.add(childHash)) {
                 List<String> pathsToPublish = new ArrayList<>();
-                List<String> candidatesToPublish = new ArrayList<>();
                 pathsToPublish.add(childPath);
-                candidatesToPublish.addAll(itemServiceInternal.getSameCommitItems(site, childPath));
-                candidatesToPublish.addAll(dependencyService.getPublishingDependencies(site, childPath));
-                for (String pathToAdd : candidatesToPublish) {
-                    String hash = DigestUtils.md2Hex(pathToAdd);
+                for (String publishDependency : dependencyService.getPublishingDependencies(site, childPath)) {
+                    String hash = DigestUtils.md2Hex(publishDependency);
                     if (processedPaths.add(hash)) {
-                        pathsToPublish.add(pathToAdd);
+                        pathsToPublish.add(publishDependency);
                     }
                 }
                 String aprover = securityService.getCurrentUser();

--- a/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
@@ -620,11 +620,6 @@ public class ItemServiceInternalImpl implements ItemServiceInternal {
     }
 
     @Override
-    public List<String> getSameCommitItems(String siteId, String path) {
-        return itemDao.getSameCommitItems(siteId, path);
-    }
-
-    @Override
     public void updateLastPublishedOn(String siteId, String path, ZonedDateTime lastPublishedOn) {
         retryingDatabaseOperationFacade.retry(() -> itemDao.updateLastPublishedOn(siteId, path, lastPublishedOn));
     }

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -115,7 +115,9 @@
         translation_source_id = #{translationSourceId},
         size = #{size},
         parent_id = #{parentId},
+        <if test="commitId != null">
         commit_id = #{commitId},
+        </if>
         previous_path = #{previousPath},
         ignored = #{ignoredAsInt}
     </insert>
@@ -1152,16 +1154,6 @@
         </foreach>
         AND (i.path = #{path} or i.path like #{likePath})
         AND (i.state &amp; #{inProgressMask}) &gt; 0
-    </select>
-
-    <select id="getSameCommitItems" resultType="String">
-        SELECT i2.path
-        FROM site s INNER JOIN item i1 ON i1.site_id = s.id
-            INNER JOIN item i2 ON s.id = i2.site_id AND i1.commit_id = i2.commit_id
-        WHERE s.site_id = #{siteId}
-        AND s.deleted = 0
-        AND i1.ignored = 0
-        AND i1.path = #{path}
     </select>
 
     <update id="updateLastPublishedOn">


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6181
Prevent updating commit id when no change. Remove 'getSameCommitItems' for bulk publish