### PR TITLE
Exclude slf4j libraries from engine overlay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,9 +634,9 @@
                                 <exclude>/WEB-INF/lib/httpclient-4.5.2.jar</exclude>
                                 <exclude>/WEB-INF/lib/httpcore-4.4.4.jar</exclude>
                                 <exclude>/WEB-INF/lib/commons-logging-1.2.jar</exclude>
-                                <exclude>/WEB-INF/lib/slf4j-api-1.7.7.jar</exclude>
-                                <exclude>/WEB-INF/lib/slf4j-log4j12-1.7.7.jar</exclude>
-                                <exclude>/WEB-INF/lib/jcl-over-slf4j-1.7.7.jar</exclude>
+                                <exclude>/WEB-INF/lib/slf4j-api-*.jar</exclude>
+                                <exclude>/WEB-INF/lib/slf4j-log4j12-*.jar</exclude>
+                                <exclude>/WEB-INF/lib/jcl-over-slf4j-*.jar</exclude>
                                 <exclude>/WEB-INF/lib/spring-security-core-4.2.7.RELEASE.jar</exclude>
                                 <exclude>/WEB-INF/templates/system/common/versionInfo.ftl</exclude>
                                 <exclude>/WEB-INF/classes/crafter/engine/services/security-context.xml</exclude>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/620
Exclude slf4j libraries from engine overlay