### PR TITLE
Use default MockMaker INLINE to prevent mvn test failed

### DIFF
--- a/src/test/java/org/craftercms/studio/test/util/BaseRepositoryTestCase.java
+++ b/src/test/java/org/craftercms/studio/test/util/BaseRepositoryTestCase.java
@@ -37,7 +37,7 @@ public abstract class BaseRepositoryTestCase extends RepositoryTestCase {
     protected static final String HEAD = "HEAD";
     protected static final String MASTER = "master";
 
-    @Mock(mockMaker = MockMakers.SUBCLASS)
+    @Mock
     protected RetryingRepositoryOperationFacade retryingRepositoryOperationFacade;
 
     @InjectMocks


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6243

In Mockito v5, INLINE is the default MockMaker. Using both seems to interfere the test and some test cases failed