### PR TITLE
ConfigurableMax annotation. Make write_configuration max length configurable

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
@@ -289,6 +289,8 @@ public interface StudioConfiguration {
     String CONFIGURATION_DASHBOARD_CONTENT_EXPIRED_SORT_BY =
             "studio.configuration.dashboard.contentExpiredQuery.sortBy";
 
+    String CONFIGURATION_MAX_CONFIGURATION_LENGTH = "studio.configuration.maxContentSize";
+
     // CORS
     String CONFIGURATION_CORS_ALLOWED_ORIGINS = "studio.cors.origins";
 

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/ConfigurationController.java
@@ -107,7 +107,7 @@ public class ConfigurationController {
 
     @Valid
     @PostMapping("/write_configuration")
-    public ResponseBody writeConfiguration(@Valid @RequestBody WriteConfigurationRequest wcRequest)
+    public ResponseBody writeConfiguration(@Validated @RequestBody WriteConfigurationRequest wcRequest)
             throws ServiceLayerException, UserNotFoundException {
         InputStream is = IOUtils.toInputStream(wcRequest.getContent(), UTF_8);
         String siteId = wcRequest.getSiteId();

--- a/src/main/java/org/craftercms/studio/model/rest/WriteConfigurationRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/WriteConfigurationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -19,10 +19,10 @@ package org.craftercms.studio.model.rest;
 import org.craftercms.commons.validation.annotations.param.EsapiValidatedParam;
 import org.craftercms.commons.validation.annotations.param.ValidConfigurationPath;
 import org.craftercms.commons.validation.annotations.param.ValidSiteId;
-
-import javax.validation.constraints.Size;
+import org.craftercms.studio.model.validation.annotations.ConfigurableMax;
 
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.ALPHANUMERIC;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.CONFIGURATION_MAX_CONFIGURATION_LENGTH;
 
 public class WriteConfigurationRequest {
 
@@ -34,7 +34,7 @@ public class WriteConfigurationRequest {
     private String path;
     @EsapiValidatedParam(type = ALPHANUMERIC)
     private String environment;
-    @Size(max = 512 * 1024)
+    @ConfigurableMax(CONFIGURATION_MAX_CONFIGURATION_LENGTH)
     private String content;
 
     public String getSiteId() {

--- a/src/main/java/org/craftercms/studio/model/validation/annotations/ConfigurableMax.java
+++ b/src/main/java/org/craftercms/studio/model/validation/annotations/ConfigurableMax.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.model.validation.annotations;
+
+import org.craftercms.studio.model.validation.validators.ConfigurableMaxValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Custom constraint annotation to validate that a string does not exceed a maximum size,
+ * while allowing to configure the maximum value via Studio configuration.
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = {ConfigurableMaxValidator.class})
+public @interface ConfigurableMax {
+
+    /**
+     * The name of the Studio configuration property to use as the maximum size
+     *
+     * @return the name of the property to use as the maximum size
+     */
+    String value();
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/org/craftercms/studio/model/validation/validators/ConfigurableMaxValidator.java
+++ b/src/main/java/org/craftercms/studio/model/validation/validators/ConfigurableMaxValidator.java
@@ -1,0 +1,38 @@
+package org.craftercms.studio.model.validation.validators;
+
+import org.craftercms.studio.api.v2.utils.StudioConfiguration;
+import org.craftercms.studio.model.validation.annotations.ConfigurableMax;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Custom validator for the {@link ConfigurableMax} annotation.
+ * It validates that the input value does not exceed the maximum length
+ * Notice that null values are considered valid.
+ */
+public class ConfigurableMaxValidator implements ConstraintValidator<ConfigurableMax, String> {
+    public static final int DEFAULT_MAX = 512 * 1024;
+
+    private final StudioConfiguration studioConfiguration;
+    private String propertyName;
+
+    public ConfigurableMaxValidator(final StudioConfiguration studioConfiguration) {
+        this.studioConfiguration = studioConfiguration;
+    }
+
+    @Override
+    public void initialize(ConfigurableMax constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+        propertyName = constraintAnnotation.value();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        int maxLength = studioConfiguration.getProperty(propertyName, Integer.class, DEFAULT_MAX);
+        if (value == null) {
+            return true;
+        }
+        return value.length() <= maxLength;
+    }
+}

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -264,6 +264,8 @@ studio.configuration.publishing.blacklist.regex: >-
   .*/\.keep
 # Default studio server time zone for date time format
 studio.configuration.defaultTimeZone: UTC
+# The maximum length of configuration content for the configuration service. Default to 512kB -> 512 * 1024
+studio.configuration.maxContentSize: 524288
 
 ########################################################
 ##                   Import Service                   ##


### PR DESCRIPTION
ConfigurableMax annotation. Make write_configuration max length configurable
https://github.com/craftercms/craftercms/issues/6710