### PR TITLE
Fixed tabulation in Studio OAS for unlock API - Ticket #6718

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -1990,41 +1990,41 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-/api/2/sites/{siteId}/unlock:
-  post:
-    tags:
-      - sites
-    summary: Unlock a site locked with state LOCKED
-    description: 'Required Permission: "edit_site"'
-    operationId: unlockSite
-    parameters:
-      - name: siteId
-        in: path
-        schema:
-          type: string
-        required: true
-    responses:
-      '200':
-        description: OK
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                response:
-                  $ref: '#/components/schemas/ApiResponse'
-                result:
-                  $ref: '#/components/schemas/ContentValidationResult'
-      '400':
-        $ref: '#/components/responses/BadRequest'
-      '401':
-        $ref: '#/components/responses/Unauthorized'
-      '403':
-        $ref: '#/components/responses/Forbidden'
-      '404':
-        $ref: '#/components/responses/NotFound'
-      '500':
-        $ref: '#/components/responses/InternalServerError'
+  /api/2/sites/{siteId}/unlock:
+    post:
+      tags:
+        - sites
+      summary: Unlock a site locked with state LOCKED
+      description: 'Required Permission: "edit_site"'
+      operationId: unlockSite
+      parameters:
+        - name: siteId
+          in: path
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response:
+                    $ref: '#/components/schemas/ApiResponse'
+                  result:
+                    $ref: '#/components/schemas/ContentValidationResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /api/2/sites/{siteId}/policy/validate:
     post:


### PR DESCRIPTION
Fixed tabulation in Studio OAS for unlock API, since it was giving problems when importing the definition into REST API tools such as Postman. 

Related with https://github.com/craftercms/craftercms/issues/6718