### PR TITLE
Prevent wrong commit id in audit table when making multiple write-content operations

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/content/ContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,11 +16,6 @@
 
 package org.craftercms.studio.api.v1.service.content;
 
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.craftercms.commons.crypto.CryptoException;
 import org.craftercms.commons.validation.ValidationException;
 import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
@@ -33,6 +28,11 @@ import org.craftercms.studio.api.v1.to.*;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.springframework.core.io.Resource;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Content Services that other services may use
@@ -148,11 +148,11 @@ public interface ContentService {
      * @param site    - the project ID
      * @param path    path to content
      * @param content stream of content to write
-     * @return return true if successful
+     * @return return new commit id
      *
      * @throws ServiceLayerException general service error
      */
-    boolean writeContent(String site, String path, InputStream content) throws ServiceLayerException;
+    String writeContent(String site, String path, InputStream content) throws ServiceLayerException;
 
     /**
      * write content from an input stream and notify the subscribers.

--- a/src/main/java/org/craftercms/studio/api/v2/dal/AuditDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/AuditDAO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -22,8 +22,7 @@ import org.craftercms.studio.model.rest.Person;
 import java.util.List;
 import java.util.Map;
 
-import static org.craftercms.studio.api.v2.dal.QueryParameterNames.COMMIT_ID;
-import static org.craftercms.studio.api.v2.dal.QueryParameterNames.SITE_ID;
+import static org.craftercms.studio.api.v2.dal.QueryParameterNames.*;
 
 public interface AuditDAO {
 
@@ -72,10 +71,12 @@ public interface AuditDAO {
      * <ul>
      *     <li>There is an audit entry for the given commit id</li>
      *     <li>AND the audit entry origin is API</li>
+     *     <li>AND the audit entry primary_target_value is the given path</li>
      * </ul>
      *
-     * @param commitId
+     * @param commitId the commit id
+     * @param path the path (to match primary_target_value)
      * @return the {@link Person} author or the commit, if found, null otherwise.
      */
-    Person getCommitAuthor(@Param(COMMIT_ID) String commitId);
+    Person getCommitAuthor(@Param(COMMIT_ID) String commitId, @Param(PATH) String path);
 }

--- a/src/main/java/org/craftercms/studio/api/v2/service/audit/internal/AuditServiceInternal.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/audit/internal/AuditServiceInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -164,10 +164,12 @@ public interface AuditServiceInternal {
      * <ul>
      *     <li>There is an audit entry for the given commit id</li>
      *     <li>AND the audit entry origin is API</li>
+     *     <li>AND the audit entry primary_target_value correspond to the given path</li>
      * </ul>
      *
      * @param commitId commit id
+     * @param path     path of the file
      * @return author of the commit, if found, otherwise null
      */
-    Person getAuthor(String commitId);
+    Person getAuthor(String commitId, String path);
 }

--- a/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/AssetDmContentProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -21,16 +21,17 @@ import org.craftercms.studio.api.v1.content.pipeline.PipelineContent;
 import org.craftercms.studio.api.v1.exception.ContentProcessException;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.craftercms.studio.api.v1.to.ContentAssetInfoTO;
 import org.craftercms.studio.api.v1.to.ContentItemTO;
 import org.craftercms.studio.api.v1.to.ResultTO;
 import org.craftercms.studio.impl.v1.util.ContentFormatUtils;
 import org.craftercms.studio.impl.v1.util.ContentUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARATOR;
 import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_CREATE;
 import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_UPDATE;
@@ -193,15 +194,14 @@ public class AssetDmContentProcessor extends FormDmContentProcessor {
     protected void updateFile(String site, String relativePath, InputStream input,
                               String user, boolean isPreview, boolean unlock, ResultTO result)
             throws ServiceLayerException, UserNotFoundException {
-        boolean success;
+        String commitId;
         try {
-            success = contentService.writeContent(site, relativePath, input);
+            commitId = contentService.writeContent(site, relativePath, input);
         } finally {
             ContentUtils.release(input);
         }
 
-        if (success) {
-            String commitId = contentRepository.getRepoLastCommitId(site);
+        if (isNotEmpty(commitId)) {
             result.setCommitId(commitId);
 
             // if there is anything pending and this is not a preview update, cancel workflow

--- a/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/FormDmContentProcessor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/content/pipeline/FormDmContentProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -45,6 +45,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.isNotEmpty;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARATOR;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.INDEX_FILE;
 import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_CREATE;
@@ -194,8 +195,7 @@ public class FormDmContentProcessor extends PathMatchProcessor implements DmCont
         String itemPath = parentItem.getUri() + FILE_SEPARATOR + fileName;
         itemPath = itemPath.replaceAll(FILE_SEPARATOR + FILE_SEPARATOR, FILE_SEPARATOR);
         try {
-            contentService.writeContent(site, itemPath, input);
-            String commitId = contentRepository.getRepoLastCommitId(site);
+            String commitId = contentService.writeContent(site, itemPath, input);
             result.setCommitId(commitId);
 
             // Item
@@ -235,16 +235,14 @@ public class FormDmContentProcessor extends PathMatchProcessor implements DmCont
     protected void updateFile(String site, String path, InputStream input, String user,
                               boolean isPreview, boolean unlock, ResultTO result)
             throws ServiceLayerException, UserNotFoundException {
-
-        boolean success;
+        String commitId;
         try {
-            success = contentService.writeContent(site, path, input);
+            commitId = contentService.writeContent(site, path, input);
         } finally {
             ContentUtils.release(input);
         }
 
-        if (success) {
-            String commitId = contentRepository.getRepoLastCommitId(site);
+        if (isNotEmpty(commitId)) {
             result.setCommitId(commitId);
 
             // if there is anything pending and this is not a preview update, cancel workflow

--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/ContentServiceImpl.java
@@ -655,7 +655,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
     @Override
     @Valid
     @HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_WRITE)
-    public boolean writeContent(@SiteId String site,
+    public String writeContent(@SiteId String site,
                                 @ProtectedResourceId(PATH_RESOURCE_ID) @ValidateSecurePathParam String path,
                                 InputStream content)
             throws ServiceLayerException {
@@ -670,8 +670,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
             contentRepository.insertGitLog(site, commitId, 1, 1);
             siteService.updateLastCommitId(site, commitId);
         }
-
-        return result;
+        return commitId;
     }
 
     @Override
@@ -681,7 +680,7 @@ public class ContentServiceImpl implements ContentService, ApplicationContextAwa
                                 @ProtectedResourceId(PATH_RESOURCE_ID) @ValidateSecurePathParam String path,
                                 InputStream content)
             throws ServiceLayerException {
-        boolean result = writeContent(site, path, content);
+        boolean result = isNotEmpty(writeContent(site, path, content));
         if (result) {
             notifyContentEvent(site, path);
         }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/audit/internal/AuditServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/audit/internal/AuditServiceInternalImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -306,8 +306,8 @@ public class AuditServiceInternalImpl implements AuditServiceInternal {
     }
 
     @Override
-    public Person getAuthor(String commitId) {
-        return auditDao.getCommitAuthor(commitId);
+    public Person getAuthor(final String commitId, final String path) {
+        return auditDao.getCommitAuthor(commitId, path);
     }
 
     public void setAuditDao(AuditDAO auditDao) {

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -319,12 +319,12 @@ public class ContentServiceInternalImpl implements ContentServiceInternal {
     }
 
     @Override
-    public List<ItemVersion> getContentVersionHistory(String siteId, String path) throws ServiceLayerException {
+    public List<ItemVersion> getContentVersionHistory(final String siteId, final String path) throws ServiceLayerException {
         try {
             List<ItemVersion> history = contentRepository.getContentItemHistory(siteId, path);
             for (ItemVersion itemVersion : history) {
                 if (itemVersion.getVersionNumber() != null) {
-                    itemVersion.setAuthor(auditServiceInternal.getAuthor(itemVersion.getVersionNumber()));
+                    itemVersion.setAuthor(auditServiceInternal.getAuthor(itemVersion.getVersionNumber(), path));
                 }
             }
             return history;

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/AuditDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/AuditDAO.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+  ~ Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License version 3 as published by
@@ -399,6 +399,7 @@
         FROM audit a
         INNER JOIN user u on u.username = a.actor_id
         WHERE a.commit_id = #{commitId}
+        AND a.primary_target_value = #{path}
         AND origin = 'API'
     </select>
 


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1000
https://github.com/craftercms/craftercms/issues/7244
Prevent wrong commit id in audit table when making multiple write-content operations