### PR TITLE
Publish APIs updates

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -6643,7 +6643,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /api/2/publish/trigger:
+  /api/2/publish/{siteId}/trigger:
     post:
       tags:
         - publishing
@@ -6652,7 +6652,7 @@ paths:
       operationId: triggerPublisher
       parameters:
         - name: siteId
-          in: query
+          in: path
           description: site ID
           required: true
           schema:
@@ -6745,7 +6745,7 @@ paths:
           $ref: '#/components/responses/InternalServerError'
 
 
-  /api/2/publish/status:
+  /api/2/publish/{siteId}/status:
     get:
       tags:
         - publishing
@@ -6754,7 +6754,7 @@ paths:
       operationId: getPublishingStatus
       parameters:
         - name: siteId
-          in: query
+          in: path
           description: site ID
           required: true
           schema:
@@ -6866,13 +6866,20 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /api/2/publish/enable:
+  /api/2/publish/{siteId}/enable:
     post:
       tags:
         - publishing
       summary: Enable/disable publishing for a site
       operationId: enablePublishing
       description: 'Required permission "start_stop_publisher"'
+      parameters:
+        - name: siteId
+          in: path
+          description: site ID
+          required: true
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -6880,10 +6887,7 @@ paths:
             schema:
               type: object
               properties:
-                siteId:
-                  type: string
-                  description: site ID
-                enabled:
+                enable:
                   type: boolean
                   description: true to enable, false to disable
               required:

--- a/src/main/java/org/craftercms/studio/api/v2/dal/DependencyDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/DependencyDAO.java
@@ -39,6 +39,8 @@ public interface DependencyDAO {
 
     /**
      * Get soft dependencies from DB for list of content paths
+     * This query is recursive, so it will get soft deps of soft deps, filtering the
+     * non-new/non-edited items at the end.
      *
      * @param site                             site identifier
      * @param paths                            list of content paths
@@ -51,6 +53,21 @@ public interface DependencyDAO {
                                                          @Param(REGEX) List<String> itemSpecificDependenciesPatterns,
                                                          @Param(MODIFIED_MASK) long modifiedMask,
                                                          @Param(NEW_MASK) long newMask);
+
+    /**
+     * Get publishing soft dependencies from DB for list of content paths
+     *
+     * @param site                             site identifier
+     * @param paths                            list of content paths
+     * @param itemSpecificDependenciesPatterns list of patterns that define item specific dependencies
+     * @param modifiedMask                     state bit mask for modified item
+     * @param newMask                          state bit mask for new item
+     * @return List of soft dependencies
+     */
+    List<Map<String, String>> getPublishingSoftDependenciesForList(@Param(SITE_ID) String site, @Param(PATHS) Set<String> paths,
+                                                                   @Param(REGEX) List<String> itemSpecificDependenciesPatterns,
+                                                                   @Param(MODIFIED_MASK) long modifiedMask,
+                                                                   @Param(NEW_MASK) long newMask);
 
     /**
      * Get hard dependencies from DB for list of content paths

--- a/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
@@ -22,7 +22,10 @@ import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.service.dependency.DependencyResolver;
 import org.craftercms.studio.model.rest.content.DependencyItem;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface DependencyService {
 
@@ -30,12 +33,26 @@ public interface DependencyService {
      * Get a soft dependencies of a list of items. A soft
      * dependency is:
      * * an edited, shared (not item specific) dependency
+     * <p>
+     * This method will also get transitive soft dependencies, even across published items.
+     * e.g.: if A depends on B and B depends on C, then A depends on C, even if B is published.
      *
      * @param site  Site to operate on
      * @param paths List of paths to items to retrieve deps for
      * @return list of soft dependencies
      */
-    Collection<String> getSoftDependencies(String site, Collection<String> paths);
+    Collection<String> getSoftDependencies(String site, Set<String> paths);
+
+    /**
+     * Get the publishing soft dependencies of a list of items. A soft
+     * dependency is:
+     * * an edited, shared (not item specific) dependency
+     *
+     * @param site  Site to operate on
+     * @param paths List of paths to items to retrieve deps for
+     * @return list of soft dependencies
+     */
+    Collection<String> getPublishingSoftDependencies(String site, Set<String> paths);
 
     /**
      * Get then hard dependencies of an item. A hard

--- a/src/main/java/org/craftercms/studio/api/v2/service/notification/NotificationService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/notification/NotificationService.java
@@ -19,6 +19,7 @@ package org.craftercms.studio.api.v2.service.notification;
 import jakarta.validation.Valid;
 import org.apache.commons.lang3.tuple.Pair;
 import org.craftercms.commons.validation.annotations.param.ValidateStringParam;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 
 import java.util.Collection;
@@ -31,7 +32,9 @@ import java.util.List;
 public interface NotificationService {
 
     /** Notification Message Keys **/
-    /** Action Completed Message Keys **/
+    /**
+     * Action Completed Message Keys
+     **/
     String COMPLETE_GO_LIVE = "go-live";
     String COMPLETE_REJECT = "reject";
     String COMPLETE_SCHEDULE_GO_LIVE = "schedule-to-go-live";
@@ -39,14 +42,14 @@ public interface NotificationService {
     String COMPLETE_DELETE = "delete";
 
     /**
-     * <p>Sends a email to configure emails when a deployment had fail</p>
-     * @param site Name of the site which the deployment fail.
-     * @param throwable Throwable error which break the deployment. (Can be null)
-     * @param filesUnableToPublish List of files that where unable to publish (can be null)
+     * <p>Sends a email to configured emails when a publishing package had fail</p>
      *
+     * @param site           the site id
+     * @param publishPackage the package that was being published
+     * @param throwable      throwable error which break the deployment. (Can be null)
+     * @param failedItems    list of publish items that where unable to publish (can be null)
      */
-    // TODO: fix for new publishing system
-//    void notifyDeploymentError(final String site, final Throwable throwable, List<PublishRequest> filesUnableToPublish);
+    void notifyPublishError(String site, PublishPackage publishPackage, Throwable throwable, Collection<PublishItem> failedItems);
 
     /**
      * Process and Sends a generic email.
@@ -56,7 +59,7 @@ public interface NotificationService {
      * @param params parameters of the message this params will be used to process the message string.
      */
     @SuppressWarnings("unchecked")
-    void notify(final String site , final List<String> toUsers ,final String key, final Pair<String,Object>...params);
+    void notify(final String site, final List<String> toUsers, final String key, final Pair<String, Object>... params);
 
     /**
      * Send a notification message to the submitter of a package that has been approved
@@ -91,8 +94,8 @@ public interface NotificationService {
      * either by key/locale it will <b>return a default string</b>) </p>
      */
     @SuppressWarnings("unchecked")
-    String getNotificationMessage(final String site , final NotificationMessageType type, final String key,
-                                  final Pair<String,Object>...params);
+    String getNotificationMessage(final String site, final NotificationMessageType type, final String key,
+                                  final Pair<String, Object>... params);
 
     /**
      * Send email to admin that repository has merged conflict

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/PublishController.java
@@ -132,10 +132,10 @@ public class PublishController {
         return result;
     }
 
-    @GetMapping(STATUS)
-    public ResultOne<PublishStatus> getPublishingStatus(@ValidSiteId @RequestParam(name = REQUEST_PARAM_SITEID) String siteId)
+    @GetMapping(PATH_PARAM_SITE + STATUS)
+    public ResultOne<PublishStatus> getPublishingStatus(@PathVariable @ValidSiteId String site)
             throws SiteNotFoundException {
-        PublishStatus status = sitesService.getPublishingStatus(siteId);
+        PublishStatus status = sitesService.getPublishingStatus(site);
         ResultOne<PublishStatus> result = new ResultOne<>();
         result.setEntity(RESULT_KEY_PUBLISH_STATUS, status);
         result.setResponse(OK);
@@ -178,9 +178,9 @@ public class PublishController {
         return result;
     }
 
-    @PostMapping(ENABLE_PUBLISHER)
-    public Result enablePublisher(@Validated @RequestBody EnablePublisherRequest request) {
-        sitesService.enablePublishing(request.getSiteId(), request.isEnable());
+    @PostMapping(PATH_PARAM_SITE + ENABLE_PUBLISHER)
+    public Result enablePublisher(@PathVariable @NotEmpty @ValidSiteId String site, @RequestBody EnablePublisherRequest request) {
+        sitesService.enablePublishing(site, request.isEnable());
         Result result = new Result();
         result.setResponse(OK);
         return result;

--- a/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
@@ -49,8 +49,16 @@ public class DependencyServiceImpl implements DependencyService {
     @RequireSiteReady
     @HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
     public Collection<String> getSoftDependencies(@SiteId String siteId,
-                                                  @ProtectedResourceId(PATH_LIST_RESOURCE_ID) Collection<String> paths) {
+                                                  @ProtectedResourceId(PATH_LIST_RESOURCE_ID) Set<String> paths) {
         return dependencyServiceInternal.getSoftDependencies(siteId, paths);
+    }
+
+    @Override
+    @RequireSiteReady
+    @HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
+    public Collection<String> getPublishingSoftDependencies(@SiteId String siteId,
+                                                  @ProtectedResourceId(PATH_LIST_RESOURCE_ID) Set<String> paths) {
+        return dependencyServiceInternal.getPublishingSoftDependencies(siteId, paths);
     }
 
     @Override

--- a/src/main/java/org/craftercms/studio/impl/v2/service/dependency/internal/DependencyServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/dependency/internal/DependencyServiceInternalImpl.java
@@ -66,15 +66,30 @@ public class DependencyServiceInternalImpl implements DependencyService {
 
     @Override
     @LogExecutionTime
-    public Collection<String> getSoftDependencies(String site, Collection<String> paths) {
+    public Collection<String> getSoftDependencies(String site, Set<String> paths) {
         logger.trace("Get all soft dependencies for site '{}' paths '{}'", site, paths);
-        Set<String> pathsParams = new HashSet<>(paths);
         Set<String> result = new HashSet<>();
-        List<Map<String, String>> deps = dependencyDao.getSoftDependenciesForList(site, pathsParams, getItemSpecificDependenciesPatterns(),
+        List<Map<String, String>> deps = dependencyDao.getSoftDependenciesForList(site, paths, getItemSpecificDependenciesPatterns(),
                 MODIFIED_MASK, NEW_MASK);
         for (Map<String, String> d : deps) {
             String targetPath = d.get(TARGET_PATH_COLUMN_NAME);
-            if (!pathsParams.contains(targetPath)) {
+            if (!paths.contains(targetPath)) {
+                result.add(targetPath);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    @LogExecutionTime
+    public Collection<String> getPublishingSoftDependencies(final String site, final Set<String> paths) {
+        logger.trace("Get all soft dependencies for site '{}' paths '{}'", site, paths);
+        Set<String> result = new HashSet<>();
+        List<Map<String, String>> deps = dependencyDao.getPublishingSoftDependenciesForList(site, paths, getItemSpecificDependenciesPatterns(),
+                MODIFIED_MASK, NEW_MASK);
+        for (Map<String, String> d : deps) {
+            String targetPath = d.get(TARGET_PATH_COLUMN_NAME);
+            if (!paths.contains(targetPath)) {
                 result.add(targetPath);
             }
         }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/marketplace/internal/MarketplaceServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/marketplace/internal/MarketplaceServiceInternalImpl.java
@@ -45,7 +45,9 @@ import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepository
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteRepositoryException;
 import org.craftercms.studio.api.v1.exception.repository.InvalidRemoteUrlException;
 import org.craftercms.studio.api.v1.exception.repository.RemoteRepositoryNotFoundException;
+import org.craftercms.studio.api.v1.exception.security.AuthenticationException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
+import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v1.service.content.ContentService;
 import org.craftercms.studio.api.v1.service.site.SiteService;
 import org.craftercms.studio.api.v2.exception.MissingPluginParameterException;
@@ -64,6 +66,7 @@ import org.craftercms.studio.api.v2.service.marketplace.registry.ConfigRecord;
 import org.craftercms.studio.api.v2.service.marketplace.registry.FileRecord;
 import org.craftercms.studio.api.v2.service.marketplace.registry.PluginRecord;
 import org.craftercms.studio.api.v2.service.marketplace.registry.PluginRegistry;
+import org.craftercms.studio.api.v2.service.publish.PublishService;
 import org.craftercms.studio.api.v2.service.site.SitesService;
 import org.craftercms.studio.api.v2.service.system.InstanceService;
 import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
@@ -109,6 +112,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
+import static java.util.Collections.emptyList;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.IOUtils.toInputStream;
@@ -191,6 +195,8 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
     protected final Lock writeLock = lock.writeLock();
 
     protected final ConfigurationService configurationService;
+    protected final PublishService publishService;
+    protected final ServicesConfig servicesConfig;
 
     /**
      * The custom HTTP headers to sent with all requests
@@ -225,7 +231,7 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
     /**
      * List of plugin types that can be installed
      */
-    protected List<String> installableTypes = Collections.emptyList();
+    protected List<String> installableTypes = emptyList();
 
     /**
      * Folder mappings to use during plugin installation
@@ -277,10 +283,11 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
 
     protected final ContentTypeService contentTypeService;
 
-    @ConstructorProperties({ "instanceService", "siteService", "sitesServiceInternal", "contentService",
+    @ConstructorProperties({"instanceService", "siteService", "sitesServiceInternal", "contentService",
             "studioConfiguration", "pluginDescriptorReader", "gitRepositoryHelper",
             "pluginDescriptorFilename", "templateCode", "templateComment", "retryingRepositoryOperationFacade",
-            "dependencyService", "contentTypeService", "configurationService"})
+            "dependencyService", "contentTypeService", "configurationService",
+            "servicesConfig", "publishService"})
     public MarketplaceServiceInternalImpl(InstanceService instanceService, SiteService siteService,
                                           SitesService sitesServiceInternal, ContentService contentService,
                                           StudioConfiguration studioConfiguration,
@@ -290,7 +297,8 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
                                           RetryingRepositoryOperationFacade retryingRepositoryOperationFacade,
                                           DependencyService dependencyService,
                                           ContentTypeService contentTypeService,
-                                          ConfigurationService configurationService) {
+                                          ConfigurationService configurationService,
+                                          ServicesConfig servicesConfig, PublishService publishService) {
         this.instanceService = instanceService;
         this.siteService = siteService;
         this.sitesServiceInternal = sitesServiceInternal;
@@ -305,6 +313,8 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
         this.dependencyService = dependencyService;
         this.contentTypeService = contentTypeService;
         this.configurationService = configurationService;
+        this.servicesConfig = servicesConfig;
+        this.publishService = publishService;
     }
 
     public void setUrl(final String url) {
@@ -473,7 +483,7 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
     @Override
     public List<PluginRecord> getInstalledPlugins(final String siteId) throws MarketplaceException {
         if (!contentService.contentExists(siteId, pluginRegistryPath)) {
-            return Collections.emptyList();
+            return emptyList();
         }
         return getPluginRegistry(siteId).getPlugins();
     }
@@ -575,8 +585,8 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
                 }
             }
         } catch (IOException | TransformerException | ServiceLayerException | DocumentException | GitAPIException |
-                PluginException | org.apache.commons.configuration2.ex.ConfigurationException |
-                UserNotFoundException e) {
+                 PluginException | org.apache.commons.configuration2.ex.ConfigurationException | UserNotFoundException |
+                 AuthenticationException e) {
             if (CollectionUtils.isNotEmpty(changedFiles)) {
                 try {
                     resetChanges(siteId, changedFiles);
@@ -823,7 +833,7 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
             // commit all changes
             commitChanges(siteId, changedFiles, true, true, "Remove plugin " + pluginId);
         } catch (IOException | GitAPIException | CommitNotFoundException | EnvironmentNotFoundException |
-                SiteNotFoundException | TransformerException | UserNotFoundException e) {
+                 SiteNotFoundException | TransformerException | UserNotFoundException | AuthenticationException e) {
             if (CollectionUtils.isNotEmpty(changedFiles)) {
                 try {
                     resetChanges(siteId, changedFiles);
@@ -942,7 +952,7 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
 
     protected void commitChanges(String siteId, List<String> changedFiles, boolean update, boolean publish,
                                  String message) throws IOException, GitAPIException, ServiceLayerException,
-            UserNotFoundException {
+            UserNotFoundException, AuthenticationException {
         logger.debug("Commit the changes in site '{}' with the message '{}'", siteId, message);
         Path siteDir = getRepoDirectory(siteId);
         try (Git git = Git.open(siteDir.toFile())) {
@@ -956,9 +966,10 @@ public class MarketplaceServiceInternalImpl implements MarketplaceServiceInterna
 
             if (publish) {
                 // publish changes
+                String liveTarget = servicesConfig.getLiveEnvironment(siteId);
                 logger.debug("Publish the changes in site '{}' with the message '{}'", siteId, message);
-                // TODO: implement for new publishing system
-//                deploymentService.publishCommits(siteId, "live", List.of(commit.getName()), message);
+                publishService.publish(siteId, liveTarget, emptyList(),
+                        List.of(commit.getName()), null, message, false);
             }
         }
     }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/notification/NotificationServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/notification/NotificationServiceImpl.java
@@ -23,6 +23,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import jakarta.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.craftercms.commons.mail.EmailUtils;
@@ -32,6 +33,7 @@ import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v1.service.content.ContentService;
 import org.craftercms.studio.api.v1.service.security.SecurityService;
 import org.craftercms.studio.api.v1.to.*;
+import org.craftercms.studio.api.v2.dal.publish.PublishItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 import org.craftercms.studio.api.v2.service.config.ConfigurationService;
 import org.craftercms.studio.api.v2.service.notification.NotificationMessageType;
@@ -69,7 +71,6 @@ public class NotificationServiceImpl implements NotificationService {
     private static final String TEMPLATE_MODEL_DEPLOYMENT_ERROR = "deploymentError";
     private static final String TEMPLATE_MODEL_FILES = "files";
     private static final String TEMPLATE_MODEL_PACKAGE = "publishPackage";
-    private static final String TEMPLATE_MODEL_SUBMITTER_USER = "submitterUser";
     private static final String TEMPLATE_MODEL_APPROVER = "approver";
     private static final String TEMPLATE_MODEL_SCHEDULED_DATE = "scheduleDate";
     private static final String TEMPLATE_MODEL_SUBMITTER = "submitter";
@@ -104,7 +105,22 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    @Valid
+    public void notifyPublishError(final String site, final PublishPackage publishPackage, final Throwable throwable,
+                                   final Collection<PublishItem> filesUnableToPublish) {
+        try {
+            final NotificationConfigTO notificationConfig = getNotificationConfig(site);
+            final Map<String, Object> templateModel = new HashMap<>();
+            templateModel.put(TEMPLATE_MODEL_PACKAGE, publishPackage);
+            templateModel.put(TEMPLATE_MODEL_DEPLOYMENT_ERROR, ExceptionUtils.getStackTrace(throwable));
+            templateModel.put(TEMPLATE_MODEL_FILES, filesUnableToPublish);
+            notify(site, notificationConfig.getDeploymentFailureNotifications(), NOTIFICATION_KEY_DEPLOYMENT_ERROR,
+                    templateModel);
+        } catch (Throwable e) {
+            logger.error("Failed to send publishing error notification for site '{}'", site, e);
+        }
+    }
+
+    @Override
     public void notifyPackageApproval(final PublishPackage publishPackage, final Collection<String> paths) {
         String siteId = publishPackage.getSite().getSiteId();
         logger.debug("Sending content approval notification for site '{}', package '{}'", siteId, publishPackage.getId());
@@ -238,7 +254,7 @@ public class NotificationServiceImpl implements NotificationService {
         if (cannedMessages.containsKey(key)) {
             final List<MessageTO> messages = cannedMessages.get(key);
             if (!messages.isEmpty()) {
-                return messages.get(0).getBody();
+                return messages.getFirst().getBody();
             }
         }
         return EMPTY;
@@ -490,6 +506,7 @@ public class NotificationServiceImpl implements NotificationService {
         this.contentService = contentService;
     }
 
+    @SuppressWarnings("unused")
     public void setEmailMessages(final EmailMessageQueueTo emailMessages) {
         this.emailMessages = emailMessages;
     }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/publish/internal/PublishServiceInternalImpl.java
@@ -163,7 +163,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
                 .collect(teeing(
                         flatMapping(requestPath -> expandPublishRequestPath(site, requestPath).stream(), toSet()),
                         flatMapping(requestPath -> (requestPath.includeSoftDeps() ?
-                                dependencyServiceInternal.getSoftDependencies(site.getSiteId(), Set.of(requestPath.path()))
+                                dependencyServiceInternal.getPublishingSoftDependencies(site.getSiteId(), Set.of(requestPath.path()))
                                 : SetUtils.<String>emptySet()).stream(), toSet()),
                         SetUtils::union
                 )));
@@ -180,9 +180,9 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
 
         Collection<String> deletedPaths = commitOperations.get(true);
 
-        Collection<String> softDependencies = dependencyServiceInternal.getSoftDependencies(siteId, corePackagePaths);
+        Collection<String> softDependencies = dependencyServiceInternal.getPublishingSoftDependencies(siteId, corePackagePaths);
         // Get hard deps of them all
-        Collection<String> hardDependencies = dependencyServiceInternal.getHardDependencies(siteId, publishingTarget, union(corePackagePaths, softDependencies));
+        Collection<String> hardDependencies = dependencyServiceInternal.getHardDependencies(siteId, publishingTarget, corePackagePaths);
         return new CalculatedPublishPackageResult(corePackagePaths, deletedPaths, hardDependencies, softDependencies);
     }
 
@@ -395,7 +395,7 @@ public class PublishServiceInternalImpl implements PublishService, ApplicationCo
             }
         }
         if (!softDepsPaths.isEmpty()) {
-            allPaths.addAll(dependencyServiceInternal.getSoftDependencies(site.getSiteId(), softDepsPaths));
+            allPaths.addAll(dependencyServiceInternal.getPublishingSoftDependencies(site.getSiteId(), softDepsPaths));
         }
 
         Map<String, ItemPathAndState> statesByPath = itemServiceInternal.getItemStates(site.getSiteId(), allPaths);

--- a/src/main/java/org/craftercms/studio/model/rest/dependency/GetSoftDependenciesRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/dependency/GetSoftDependenciesRequestBody.java
@@ -22,6 +22,7 @@ import org.craftercms.commons.validation.annotations.param.ValidSiteId;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import java.util.Set;
 
 public class GetSoftDependenciesRequestBody {
 
@@ -29,7 +30,7 @@ public class GetSoftDependenciesRequestBody {
     @ValidSiteId
     private String siteId;
     @NotEmpty
-    private List<@ValidExistingContentPath @NotBlank String> paths;
+    private Set<@ValidExistingContentPath @NotBlank String> paths;
 
     public String getSiteId() {
         return siteId;
@@ -39,11 +40,11 @@ public class GetSoftDependenciesRequestBody {
         this.siteId = siteId;
     }
 
-    public List<String> getPaths() {
+    public Set<String> getPaths() {
         return paths;
     }
 
-    public void setPaths(List<String> paths) {
+    public void setPaths(Set<String> paths) {
         this.paths = paths;
     }
 }

--- a/src/main/java/org/craftercms/studio/model/rest/publish/EnablePublisherRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/publish/EnablePublisherRequest.java
@@ -16,16 +16,10 @@
 
 package org.craftercms.studio.model.rest.publish;
 
-import jakarta.validation.constraints.NotEmpty;
-import org.craftercms.commons.validation.annotations.param.ValidSiteId;
-
 /**
  * Request to enable/disable the publisher task for a site
  */
 public class EnablePublisherRequest {
-    @NotEmpty
-    @ValidSiteId
-    private String siteId;
     private boolean enable;
 
     public boolean isEnable() {
@@ -36,11 +30,4 @@ public class EnablePublisherRequest {
         this.enable = enable;
     }
 
-    public @NotEmpty @ValidSiteId String getSiteId() {
-        return siteId;
-    }
-
-    public void setSiteId(@NotEmpty @ValidSiteId String siteId) {
-        this.siteId = siteId;
-    }
 }

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/DependencyDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/DependencyDAO.xml
@@ -42,7 +42,7 @@
             UNION
                 SELECT d.source_path, d.target_path, d.site
                 FROM cte, dependency d
-                        WHERE cte.target_path = d.source_path
+                WHERE cte.target_path = d.source_path
                 AND d.site = #{siteId}
                 AND cte.site = #{siteId}
                 AND d.valid = 1
@@ -60,6 +60,29 @@
                      open="(" separator=" OR " close=")">
                 cte.target_path NOT RLIKE #{pattern}
             </foreach>
+    </select>
+
+    <select id="getPublishingSoftDependenciesForList" resultType="java.util.Map">
+        SELECT d.source_path, d.target_path, d.site
+        FROM dependency d
+            INNER JOIN site s ON s.site_id = d.site
+            INNER JOIN item i ON i.path = d.target_path
+        WHERE d.source_path IN
+            <foreach item="path" index="index" collection="paths"
+                     open="(" separator="," close=")">
+                #{path}
+                </foreach>
+        AND d.site = #{siteId}
+        AND d.valid = 1
+        AND
+            <foreach item="pattern" index="index" collection="regex"
+                     open="(" separator=" OR " close=")">
+                d.target_path NOT RLIKE #{pattern}
+            </foreach>
+        AND i.site_id = s.id
+        AND s.deleted = 0
+        AND (i.state &amp; #{modifiedMask}) > 0
+        AND (i.state &amp; #{newMask}) = 0
     </select>
 
     <!-- Recursively get:

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -292,25 +292,34 @@
     </select>
 
     <select id="getSandboxItemsById" resultMap="ItemMap">
+        WITH submission AS (
+            SELECT ipi1.item_id as item_id, pp1.submitter_id AS submitter, pp1.submitted_on AS submitted_on
+            FROM item_publish_item ipi1
+                INNER JOIN publish_item pi1 ON ipi1.publish_item_id = pi1.id
+                INNER JOIN publish_package pp1 ON pi1.package_id = pp1.id
+            WHERE ipi1.item_id IN
+                    <foreach collection="itemIds" item="id" index="index" open="(" close=")" separator=",">
+                        #{id}
+                    </foreach>
+            AND (pp1.package_state &amp; #{packageState}) > 0
+            AND pp1.approval_state IN
+                    <foreach collection="approvalStates" item="approvalState" index="index" open="(" close=")" separator=",">
+                        #{approvalState}
+                    </foreach>
+        )
         SELECT i.*, i.locked_by AS lock_owner, i.created_by AS creator,
                 i.last_modified_by AS modifier,
                 submission.submitted_on AS submitted_on,
                 submission.submitter AS submitter,
-               COUNT(DISTINCT i3.id) AS children_count
+                    (SELECT COUNT(1)
+                    FROM item child_i
+                    WHERE child_i.parent_id = i.id
+                    AND (child_i.ignored = 0 OR child_i.ignored IS NULL)
+                    AND (child_i.system_type &lt;&gt; 'folder' OR NOT EXISTS
+                        (SELECT * FROM item i10 WHERE i10.site_id = child_i.site_id
+                            AND i10.path = CONCAT(child_i.path, '/index.xml')))) AS children_count
         FROM item i
-            LEFT OUTER JOIN item i3 ON i.id = i3.parent_id
-            LEFT OUTER JOIN (
-                        SELECT ipi1.item_id as item_id, pp1.submitter_id AS submitter, pp1.submitted_on AS submitted_on
-                        FROM item_publish_item ipi1
-                            INNER JOIN publish_item pi1 ON ipi1.publish_item_id = pi1.id
-                            INNER JOIN publish_package pp1 ON pi1.package_id = pp1.id
-                        WHERE (pp1.package_state &amp; #{packageState}) > 0
-                        AND pp1.approval_state IN
-                                <foreach collection="approvalStates" item="approvalState" index="index" open="(" close=")" separator=",">
-                                    #{approvalState}
-                                </foreach>
-                        ORDER BY pp1.submitted_on DESC LIMIT 0, 1 <!-- Get the most recently submitted active publish request -->
-                ) as submission ON submission.item_id = i.id
+            LEFT OUTER JOIN submission ON submission.item_id = i.id
         WHERE i.id IN
         <foreach collection="itemIds" item="id" index="index" open="(" close=")" separator=",">
             #{id}

--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/workflow/notification-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/workflow/notification-config.xml
@@ -84,7 +84,7 @@
                             </p>
                         </body>
                     </html>
-]]></body>
+            ]]></body>
         </emailTemplate>
 
         <emailTemplate key="contentApproved">


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/6766
Publish API tweaks:
- Update publishing dependencies calculation not to follow transitive dependencies
- Fix getSandboxById query to retrieve all items and workflow data
- Adding 'notifyDeploymentError' back taking a list of PublishItem
- Publish plugin changes when removing plugin
- Update API URLs to be consistent (site id in path)