### PR TITLE
Fix query for renamed children of hard deps. Include the item itself (not parent only) when calculating renamed children

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.craftercms.studio.permissions.CompositePermissionResolverImpl.PATH_LIST_RESOURCE_ID;
-import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_CONTENT_DELETE;
 import static org.craftercms.studio.permissions.StudioPermissionsConstants.PERMISSION_CONTENT_READ;
 
 public class DependencyServiceImpl implements DependencyService {

--- a/src/main/java/org/craftercms/studio/impl/v2/service/dependency/internal/DependencyServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/dependency/internal/DependencyServiceInternalImpl.java
@@ -100,7 +100,8 @@ public class DependencyServiceInternalImpl implements DependencyServiceInternal 
     @RequireSiteExists
     public List<String> getHardDependencies(@SiteId String site, List<String> paths) {
         Map<String, String> dependencies = calculateHardDependencies(site, paths);
-        return new ArrayList<>(dependencies.keySet());
+        // Prevent returning the paths as dependencies of themselves
+        return List.copyOf(CollectionUtils.subtract(dependencies.keySet(), paths));
     }
 
     /**
@@ -134,12 +135,11 @@ public class DependencyServiceInternalImpl implements DependencyServiceInternal 
         logger.trace("Get all hard dependencies for site '{}' paths '{}'", site, paths);
         Set<String> pathsParams = new HashSet<>(paths);
         List<String> mandatoryParents = getMandatoryParents(site, paths);
-        List<String> mpAsList = new ArrayList<>(mandatoryParents);
         Map<String, String> ancestors = new HashMap<>();
         if (isNotEmpty(mandatoryParents)) {
             pathsParams.addAll(mandatoryParents);
             Set<String> existingRenamedChildrenOfMandatoryParents =
-                    getExistingRenamedChildrenOfMandatoryParents(site, mpAsList);
+                    getExistingRenamedChildrenOfMandatoryParents(site, mandatoryParents);
             for (String p3 : existingRenamedChildrenOfMandatoryParents) {
                 ancestors.put(p3, p3);
             }

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -1071,6 +1071,19 @@
         </foreach>
         AND (i4.state &amp; #{modifiedMask}) > 0
         AND i4.system_type &lt;&gt; #{systemTypeFolder}
+        UNION
+        <!-- Include each path itself if it is renamed -->
+        SELECT i.path
+        FROM item i INNER JOIN site s ON i.site_id = s.id
+        WHERE s.site_id = #{siteId}
+        AND s.deleted = 0
+        AND i.ignored = 0
+        AND i.path IN
+            <foreach item="path" index="index" collection="possibleParents"
+                     open="(" separator="," close=")">
+                    #{path}
+            </foreach>
+        AND i.previous_path IS NOT NULL
     </select>
 
     <select id="getExistingRenamedChildrenOfMandatoryParentsForPublishing" parameterType="java.util.Map" resultType="String">
@@ -1083,7 +1096,7 @@
         AND (i1.state &amp; #{modifiedMask}) > 0
         AND (i1.state &amp; #{newMask}) = 0
         AND i1.parent_id IN
-        (SELECT 12.id FROM item i2 INNER JOIN site s2 ON i2.site_id = s2.id
+        (SELECT i2.id FROM item i2 INNER JOIN site s2 ON i2.site_id = s2.id
         WHERE s2.site_id = #{siteId} AND s2.deleted = 0
         AND i2.ignored = 0
         AND i2.path IN


### PR DESCRIPTION
Fix query for renamed children of hard deps. Include the item itself (not parent only) when calculating renamed children
https://github.com/craftercms/craftercms/issues/7713