### PR TITLE
Switch to CGit for repository cleaning on startup

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
@@ -657,6 +657,38 @@ public class GitRepositoryHelper implements DisposableBean {
 		config.save();
 	}
 
+	/**
+	 * Check if the git status command responds without errors.
+	 * If the status check fails, it might be because the repository is corrupted.
+	 *
+	 * @param repo repository to check
+	 * @return true if the status is OK, false otherwise
+	 */
+	public boolean gitStatusOk(Repository repo) {
+		try {
+			gitCli.isRepoClean(repo.getWorkTree().getAbsolutePath());
+			// OK if no exception is thrown
+			return true;
+		} catch (GitCliException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Remove the .git/index file and reset and clean the repository:
+	 * rm .git/index
+	 * git reset --hard
+	 * git clean -fd
+	 *
+	 * @param repoPath path to the repository
+	 * @throws IOException if an error occurred while cleaning the repository
+	 */
+	public void removeIndexAndClean(String repoPath) throws IOException {
+		GitUtils.deleteGitIndex(repoPath);
+		gitCli.resetHard(repoPath);
+		gitCli.clean(repoPath, true, true);
+	}
+
 	public String getCommitMessage(String commitMessageKey) {
 		String prologue = studioConfiguration.getProperty(REPO_COMMIT_MESSAGE_PROLOGUE);
 		String postscript = studioConfiguration.getProperty(REPO_COMMIT_MESSAGE_POSTSCRIPT);

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/RepositoryStartupCleanup.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/RepositoryStartupCleanup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,32 +16,25 @@
 
 package org.craftercms.studio.impl.v2.repository;
 
-import org.springframework.context.event.EventListener;
+import org.craftercms.commons.git.utils.GitUtils;
+import org.craftercms.studio.api.v1.constant.GitRepositories;
+import org.craftercms.studio.api.v1.service.GeneralLockService;
+import org.craftercms.studio.api.v1.service.site.SiteService;
+import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
+import org.craftercms.studio.impl.v2.utils.spring.event.CleanupRepositoriesEvent;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.ResetCommand;
-import org.eclipse.jgit.api.CleanCommand;
 import org.eclipse.jgit.errors.CorruptObjectException;
 import org.eclipse.jgit.lib.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.io.EOFException;
-import java.io.File;
-
-import org.craftercms.commons.git.utils.GitUtils;
-
-import org.craftercms.studio.api.v1.service.GeneralLockService;
-import org.craftercms.studio.api.v1.service.site.SiteService;
-import org.craftercms.studio.api.v1.constant.GitRepositories;
-import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 
 import static org.craftercms.studio.api.v1.constant.GitRepositories.PUBLISHED;
 import static org.craftercms.studio.api.v1.constant.GitRepositories.SANDBOX;
-import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARATOR;
-
-import org.craftercms.studio.impl.v2.utils.spring.event.CleanupRepositoriesEvent;
 
 /**
  * Clean up git repositories on startup
@@ -92,6 +85,7 @@ public class RepositoryStartupCleanup {
 	}
 
 	protected void unlockRepository(String siteId, GitRepositories repository) {
+		logger.debug("Unlock repository '{}' for site '{}'", repository, siteId);
 		Path repoPath = helper.buildRepoPath(repository, siteId);
 		if (repoPath != null) {
 			String path = repoPath.toAbsolutePath().toString();
@@ -106,50 +100,18 @@ public class RepositoryStartupCleanup {
 	}
 
 	protected void removeIndexIfCorrupted(String siteId, GitRepositories repository) {
+		logger.debug("Checking if repository '{}' for site '{}' is corrupted", repository, siteId);
 		Repository repo = helper.getRepository(siteId, repository);
-		if (isRepositoryCorrupted(repo)) {
-			String repoPath = repo.getWorkTree().getAbsolutePath();
-			try {
+		String repoPath = repo.getWorkTree().getAbsolutePath();
+		try {
+			if (!helper.gitStatusOk(repo)) {
 				logger.warn("The local repository '{}' is corrupt, trying to fix it", repoPath);
-				try (Git git = new Git(repo)) {
-					GitUtils.deleteGitIndex(repoPath);
-
-					ResetCommand resetCommand = git.reset();
-					resetCommand.setMode(ResetCommand.ResetType.HARD);
-					resetCommand.call();
-
-					CleanCommand cleanupCommand = git.clean();
-					cleanupCommand.setForce(true);
-					cleanupCommand.call();
-
-					logger.info(".git/index is deleted from local repository '{}'", repoPath);
-				} catch (Exception e) {
-					// rollback delete operation of .git/index in case reset/clean commands failed
-					String fileName = GitUtils.GIT_FOLDER_NAME + FILE_SEPARATOR + GitUtils.GIT_INDEX_NAME;
-					File indexFile = new File(repoPath, fileName);
-					if (!indexFile.exists()) {
-						indexFile.createNewFile();
-					}
-				}
-			} catch (IOException e) {
-				logger.error("Error cleaning up git repository '{}'", repoPath, e);
+				helper.removeIndexAndClean(repoPath);
+				logger.info(".git/index is deleted from local repository '{}'", repoPath);
 			}
+		} catch (IOException e) {
+			logger.error("Error cleaning up git repository '{}'", repoPath, e);
 		}
-	}
-
-	protected boolean isRepositoryCorrupted(Repository repository) {
-		if (repository == null) {
-			return false;
-		}
-
-		try (Git git = new Git(repository)) {
-			git.status().call();
-		} catch (Exception e) {
-			Throwable cause = e.getCause();
-			return cause instanceof CorruptObjectException || cause instanceof EOFException;
-		}
-
-		return false;
 	}
 
 	public void setSiteService(final SiteService siteService) {

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
@@ -399,7 +399,7 @@ public class GitCli {
 			// No result means there's no changes, so the repo is clean
 			return StringUtils.isEmpty(result);
 		} catch (Exception e) {
-			throw new GitCliException("Git GC failed on directory " + directory, e);
+			throw new GitCliException("Git status failed on directory " + directory, e);
 		}
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
@@ -18,6 +18,7 @@ package org.craftercms.studio.impl.v2.utils.git;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.craftercms.studio.api.v2.exception.git.cli.GitCliException;
 import org.craftercms.studio.api.v2.exception.git.cli.GitCliOutputException;
 import org.craftercms.studio.api.v2.task.TaskProgress;
@@ -377,6 +378,67 @@ public class GitCli {
 				stage.advanceOne();
 			});
 			executeGitCommand(directory.getAbsolutePath(), rmCommand);
+		}
+	}
+
+	/**
+	 * Check if the repository is clean, meaning there are no changes to commit
+	 *
+	 * @param directory the git repository directory
+	 * @return true if the repository is clean, false otherwise
+	 * @throws GitCliException if the git status command fails
+	 */
+	public boolean isRepoClean(String directory) throws GitCliException {
+		GitCommandLine statusCl = new GitCommandLine("status");
+		// The --porcelain option is a short version specifically for scripts
+		statusCl.addParam("--porcelain");
+
+		try {
+			String result = executeGitCommand(directory, statusCl, DEFAULT_EX_RESOLVER);
+
+			// No result means there's no changes, so the repo is clean
+			return StringUtils.isEmpty(result);
+		} catch (Exception e) {
+			throw new GitCliException("Git GC failed on directory " + directory, e);
+		}
+	}
+
+	/**
+	 * Git reset --hard
+	 *
+	 * @param repoPath the git repository directory
+	 * @return the output of the git reset command
+	 * @throws GitCliException if the git reset command fails
+	 */
+	public String resetHard(String repoPath) throws GitCliException {
+		GitCommandLine resetCl = new GitCommandLine("reset", "--hard");
+		try {
+			return StringUtils.trim(executeGitCommand(repoPath, resetCl));
+		} catch (Exception e) {
+			throw new GitCliException("Git reset --hard failed on directory " + repoPath, e);
+		}
+	}
+
+	/**
+	 * Git clean (optionally -f)
+	 *
+	 * @param repoPath  the git repository directory
+	 * @param force     true to force clean
+	 * @param recursive true to clean directories recursively
+	 * @throws GitCliException if the git clean command fails
+	 */
+	public void clean(String repoPath, boolean force, boolean recursive) throws GitCliException {
+		GitCommandLine cleanCl = new GitCommandLine("clean");
+		if (force) {
+			cleanCl.addParam("-f");
+		}
+		if (recursive) {
+			cleanCl.addParam("-d");
+		}
+		try {
+			executeGitCommand(repoPath, cleanCl);
+		} catch (Exception e) {
+			throw new GitCliException("Git clean failed on directory " + repoPath, e);
 		}
 	}
 


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1101
Switch to CGit for repository cleaning on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced repository management with new methods for checking repository status and performing cleanup operations.
  
- **Refactor**
  - Streamlined maintenance workflows and error handling for repository cleanup, resulting in a more reliable and efficient process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->