### PR TITLE
Externally managed users check in the public service

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/security/UserServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/security/UserServiceImpl.java
@@ -39,6 +39,19 @@ import static org.craftercms.studio.permissions.StudioPermissionsConstants.*;
 public class UserServiceImpl implements UserService {
 	private UserService userServiceInternal;
 
+
+	/**
+	 * Check if updating users list contains any externally managed users.
+	 * If matched, the operation must not be permitted.
+	 */
+	// TODO JM: Consider making this an annotation
+	private void checkExternallyManagedUsers(List<Long> userIds, List<String> usernames) throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {
+		List<User> users = getUsersByIdOrUsername(userIds, usernames);
+		if (users.stream().anyMatch(User::isExternallyManaged)) {
+			throw new UserExternallyManagedException("Cannot update externally managed users.");
+		}
+	}
+
 	@Override
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_READ_USERS)
 	public Collection<User> getAllUsersForSite(long orgId, String siteId, String keyword, int offset, int limit, String sort)
@@ -73,6 +86,7 @@ public class UserServiceImpl implements UserService {
 	@Override
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_UPDATE_USERS)
 	public void updateUser(User user) throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException {
+		checkExternallyManagedUsers(List.of(user.getId()), List.of(user.getUsername()));
 		userServiceInternal.updateUser(user);
 	}
 
@@ -98,6 +112,7 @@ public class UserServiceImpl implements UserService {
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_DELETE_USERS)
 	public void deleteUsers(List<Long> userIds, List<String> usernames)
 		throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException, AuthenticationException, GroupNotFoundException {
+		checkExternallyManagedUsers(userIds, usernames);
 		userServiceInternal.deleteUsers(userIds, usernames);
 	}
 
@@ -113,6 +128,7 @@ public class UserServiceImpl implements UserService {
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_UPDATE_USERS)
 	public List<User> enableUsers(List<Long> userIds, List<String> usernames,
 					      boolean enabled) throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException {
+		checkExternallyManagedUsers(userIds, usernames);
 		return userServiceInternal.enableUsers(userIds, usernames, enabled);
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/security/internal/UserServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/security/internal/UserServiceInternalImpl.java
@@ -309,8 +309,6 @@ public class UserServiceInternalImpl implements UserService, ApplicationEventPub
 
 	@Override
 	public void updateUser(User user) throws UserNotFoundException, ServiceLayerException, UserExternallyManagedException {
-		checkExternallyManagedUsers(List.of(user.getId()), List.of(user.getUsername()));
-
 		long userId = user.getId();
 		String username = user.getUsername() != null ? user.getUsername() : StringUtils.EMPTY;
 
@@ -347,17 +345,6 @@ public class UserServiceInternalImpl implements UserService, ApplicationEventPub
 	}
 
 	/**
-	 * Check if updating users list contains any externally managed users.
-	 * If matched, the operation must not be permitted.
-	 */
-	private void checkExternallyManagedUsers(List<Long> userIds, List<String> usernames) throws UserNotFoundException, UserExternallyManagedException, ServiceLayerException {
-		List<User> users = getUsersByIdOrUsername(userIds, usernames);
-		if (users.stream().anyMatch(User::isExternallyManaged)) {
-			throw new UserExternallyManagedException("Cannot update externally managed users.");
-		}
-	}
-
-	/**
 	 * Audit the deletion of the given users.
 	 */
 	private void auditDeleteUsers(List<User> deleted) throws SiteNotFoundException {
@@ -385,7 +372,6 @@ public class UserServiceInternalImpl implements UserService, ApplicationEventPub
 	public void deleteUsers(final List<Long> userIds, final List<String> usernames)
 		throws UserNotFoundException, ServiceLayerException, AuthenticationException, UserExternallyManagedException {
 		User currentUser = getCurrentUser();
-		checkExternallyManagedUsers(userIds, usernames);
 
 		if (CollectionUtils.containsAny(userIds, List.of(currentUser.getId())) ||
 			CollectionUtils.containsAny(usernames, List.of(currentUser.getUsername()))) {
@@ -492,8 +478,7 @@ public class UserServiceInternalImpl implements UserService, ApplicationEventPub
 
 	@Override
 	public List<User> enableUsers(List<Long> userIds, List<String> usernames, boolean enabled)
-		throws ServiceLayerException, UserNotFoundException, UserExternallyManagedException {
-		checkExternallyManagedUsers(userIds, usernames);
+		throws ServiceLayerException, UserNotFoundException {
 		List<User> users = getUsersByIdOrUsername(userIds, usernames);
 
 		Map<String, Object> params = new HashMap<>();


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7542
Externally managed users check in the public service to prevent legitimate updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Public user management operations now include enhanced checks that block modifications to externally managed accounts, providing clear error feedback when such actions are attempted.
- **Refactor**
  - Internal account operations have been adjusted to remove these restrictions, permitting modifications on externally managed accounts without enforcing the previous checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->