### PR TITLE
Redirect command output to files to prevent process locking when there are large outputs

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
@@ -632,7 +632,7 @@ public class GitRepositoryHelper implements DisposableBean {
         if (gitCliEnabled) {
             // The first git commit of a new repository takes a long time with Git CLI. A git status first seems
             // to fix the issue
-            gitCli.isRepoClean(repo.getWorkTree().getAbsolutePath());
+            gitCli.isRepoClean(repo.getWorkTree());
         }
     }
 
@@ -645,7 +645,7 @@ public class GitRepositoryHelper implements DisposableBean {
      */
     public boolean gitStatusOk(Repository repo) {
         try {
-            gitCli.isRepoClean(repo.getWorkTree().getAbsolutePath());
+            gitCli.isRepoClean(repo.getWorkTree());
             // OK if no exception is thrown
             return true;
         } catch (GitCliException e) {
@@ -659,14 +659,15 @@ public class GitRepositoryHelper implements DisposableBean {
      * git reset --hard
      * git clean -fd
      *
-     * @param repoPath path to the repository
+     * @param repoDir path to the repository
      * @throws IOException if an error occurred while cleaning the repository
      */
-    public void removeIndexAndClean(String repoPath) throws IOException {
-        GitUtils.deleteGitIndex(repoPath);
-        gitCli.resetHard(repoPath);
-        gitCli.clean(repoPath, true, true);
+    public void removeIndexAndClean(File repoDir) throws IOException {
+        GitUtils.deleteGitIndex(repoDir.getAbsolutePath());
+        gitCli.resetHard(repoDir);
+        gitCli.clean(repoDir, true, true);
     }
+
 
     public String getCommitMessage(String commitMessageKey) {
         String prologue = studioConfiguration.getProperty(REPO_COMMIT_MESSAGE_PROLOGUE);
@@ -1233,7 +1234,7 @@ public class GitRepositoryHelper implements DisposableBean {
             try {
                 if (gitCliEnabled) {
                     retryingRepositoryOperationFacade.call((Callable<Void>) () -> {
-                        gitCli.add(repo.getWorkTree().getAbsolutePath(), getGitPaths(paths));
+                        gitCli.add(repo.getWorkTree(), getGitPaths(paths));
                         return null;
                     });
                 } else {
@@ -1282,7 +1283,7 @@ public class GitRepositoryHelper implements DisposableBean {
                 String author = user.getName() + " <" + user.getEmailAddress() + ">";
 
                 commitId = retryingRepositoryOperationFacade.call(
-                        () -> gitCli.commit(repo.getWorkTree().getAbsolutePath(),
+                        () -> gitCli.commit(repo.getWorkTree(),
                                             author, comment, getGitPaths(paths)));
                 // Check if commit id matches jgit
                 ObjectId jgitHead = repo.resolve(HEAD);
@@ -1359,7 +1360,7 @@ public class GitRepositoryHelper implements DisposableBean {
         // TODO: JM: Refactor this class to implement Strategy pattern and get rid of these if-else statements
         if (gitCliEnabled) {
             try {
-                gitCli.restore(repo.getWorkTree().getAbsolutePath(), getGitPaths(paths));
+                gitCli.restore(repo.getWorkTree(), getGitPaths(paths));
             } catch (GitCliException e) {
                 logger.error("Failed to restore files in site '{}' paths '{}'", site, ArrayUtils.toString(paths), e);
             }

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/RepositoryStartupCleanup.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/RepositoryStartupCleanup.java
@@ -106,15 +106,15 @@ public class RepositoryStartupCleanup {
     protected void removeIndexIfCorrupted(String siteId, GitRepositories repository) {
         logger.debug("Checking if repository '{}' for site '{}' is corrupted", repository, siteId);
         Repository repo = helper.getRepository(siteId, repository);
-        String repoPath = repo.getWorkTree().getAbsolutePath();
+        File repoDir = repo.getWorkTree();
         try {
             if (!helper.gitStatusOk(repo)) {
-                logger.warn("The local repository '{}' is corrupt, trying to fix it", repoPath);
-                helper.removeIndexAndClean(repoPath);
-                logger.info(".git/index is deleted from local repository '{}'", repoPath);
+                logger.warn("The local repository '{}' is corrupt, trying to fix it", repoDir.getAbsolutePath());
+                helper.removeIndexAndClean(repoDir);
+                logger.info(".git/index is deleted from local repository '{}'", repoDir.getAbsolutePath());
             }
         } catch (IOException e) {
-            logger.error("Error cleaning up git repository '{}'", repoPath, e);
+            logger.error("Error cleaning up git repository '{}'", repoDir.getAbsolutePath(), e);
         }
     }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
@@ -15,6 +15,7 @@
  */
 package org.craftercms.studio.impl.v2.utils.git;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -28,16 +29,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static com.rometools.utils.Strings.trim;
 import static java.lang.String.format;
+import static org.craftercms.studio.api.v1.constant.StudioConstants.TMP_FILE_SUFFIX;
+import static org.craftercms.studio.api.v2.utils.StudioUtils.getStudioTemporaryFilesRoot;
 
 /**
  * Allows doing Git operations throw the CLI.
@@ -56,6 +59,8 @@ public class GitCli {
     private static final String DEFAULT_GIT_COMMAND_NAME = "git";
     private static final int DEFAULT_GIT_PROC_WAIT_FOR_TIMEOUT = 60 * 5; // 5 minutes
     private static final int DEFAULT_GIT_PROC_DESTROY_WAIT_FOR_TIMEOUT = 30;
+    // Default max number of bytes to read from process output
+    private static final int MAX_PROCESS_OUTPUT_BYTES = 1000;
 
     // Exception resolvers
     public final GitCliOutputExceptionResolver DEFAULT_EX_RESOLVER = RepositoryLockedExceptionResolver.INSTANCE;
@@ -65,81 +70,115 @@ public class GitCli {
     private final String gitProcName;
     private final int gitProcWaitForTimeoutSecs;
     private final int gitProcDestroyWaitForTimeoutSecs;
+    private final int maxProcessOutputBytes;
 
     public GitCli() {
-        this.gitProcName = DEFAULT_GIT_COMMAND_NAME;
-        this.gitProcWaitForTimeoutSecs = DEFAULT_GIT_PROC_WAIT_FOR_TIMEOUT;
-        this.gitProcDestroyWaitForTimeoutSecs = DEFAULT_GIT_PROC_DESTROY_WAIT_FOR_TIMEOUT;
+        this(DEFAULT_GIT_COMMAND_NAME, DEFAULT_GIT_PROC_WAIT_FOR_TIMEOUT, DEFAULT_GIT_PROC_DESTROY_WAIT_FOR_TIMEOUT, MAX_PROCESS_OUTPUT_BYTES);
     }
 
-    public GitCli(String gitProcName, int gitProcWaitForTimeoutSecs, int gitProcDestroyWaitForTimeoutSecs) {
+    public GitCli(String gitProcName, int gitProcWaitForTimeoutSecs,
+                  int gitProcDestroyWaitForTimeoutSecs, int maxProcessOutputBytes) {
         this.gitProcName = gitProcName;
         this.gitProcWaitForTimeoutSecs = gitProcWaitForTimeoutSecs;
         this.gitProcDestroyWaitForTimeoutSecs = gitProcDestroyWaitForTimeoutSecs;
+        this.maxProcessOutputBytes = maxProcessOutputBytes;
     }
 
-    protected String executeGitCommand(String directory, GitCommandLine commandLine)
-            throws IOException, InterruptedException {
-        return executeGitCommand(directory, commandLine, DEFAULT_EX_RESOLVER);
+    private void executeGitCommand(GitCommandLine commandLine) throws IOException, InterruptedException {
+        doExecuteGitCommand(commandLine);
     }
 
-    protected String executeGitCommand(String directory, GitCommandLine commandLine, GitCliOutputExceptionResolver exceptionResolver)
-            throws IOException, InterruptedException {
-        checkGitDirectory(directory);
-
-        ProcessBuilder pb = new ProcessBuilder(commandLine).directory(new File(directory));
-        logger.debug("Executing git command: '{}'", commandLine);
-
-        // Start process
-        Process p = pb.start();
-
-        InputStream processInputStream = p.getInputStream();
-        InputStream processErrorStream = p.getErrorStream();
+    /**
+     * Convenience method to execute a git command and return the output as a string when the
+     * expected output is "short". e.g.: git rev-parse HEAD
+     * It will read the first <code>maxProcessOutputBytes</code> bytes of the output file
+     */
+    private String executeShortOutputGitCommand(GitCommandLine commandLine) throws IOException, InterruptedException {
+        File outputTempFile = Files.createTempFile(getStudioTemporaryFilesRoot(), UUID.randomUUID().toString(), TMP_FILE_SUFFIX).toFile();
         try {
-            // Wait for the process to finish, up to gitProcWaitForTimeoutSecs
-            boolean exited = p.waitFor(gitProcWaitForTimeoutSecs, TimeUnit.SECONDS);
-            if (!exited) {
-                handleProcessTimeout(p, directory, processInputStream, processErrorStream);
-            }
-
-            int exitValue = p.exitValue();
-            if (exitValue != 0) {
-                handleErrorExitValue(directory, exceptionResolver, p, processInputStream);
-            }
-
-            // Read std output if process has finished successfully
-            String output = IOUtils.toString(p.getInputStream(), Charset.defaultCharset());
-            logger.debug("Git command successfully executed on '{}':\n'{}'", directory, output);
-            return output;
+            commandLine.setOutput(outputTempFile);
+            doExecuteGitCommand(commandLine);
+            return trim(readFileFirstBytes(outputTempFile));
         } finally {
-            IOUtils.closeQuietly(processInputStream);
-            IOUtils.closeQuietly(processErrorStream);
-            if (p.isAlive()) {
-                // Destroy process
-                destroyProcess(p);
-            }
+            FileUtils.deleteQuietly(outputTempFile);
         }
     }
 
-    private void handleErrorExitValue(String directory, GitCliOutputExceptionResolver exceptionResolver,
-                                      Process p, InputStream processInputStream) throws IOException {
-        int exitValue = p.exitValue();
-        String errorOutput = IOUtils.toString(p.getErrorStream(), Charset.defaultCharset());
-        String stdOutput = IOUtils.toString(processInputStream, Charset.defaultCharset());
+    /**
+     * Reads the contents of a file into a string.
+     * This method will read the first <code>maxProcessOutputBytes</code> bytes of the file.
+     */
+    private String readFileFirstBytes(File file) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            byte[] buffer = new byte[maxProcessOutputBytes];
+            IOUtils.read(fis, buffer);
+            return new String(buffer);
+        }
+    }
 
+    protected void doExecuteGitCommand(GitCommandLine commandLine)
+            throws IOException, InterruptedException {
+        File directory = commandLine.getDirectory();
+        checkGitDirectory(directory);
+        ProcessBuilder pb = new ProcessBuilder(commandLine).directory(directory);
+        if (commandLine.input != null) {
+            pb.redirectInput(commandLine.input);
+        }
+
+        logger.debug("Executing git command: '{}'", commandLine);
+        File errorTempFile = Files.createTempFile(getStudioTemporaryFilesRoot(), UUID.randomUUID().toString(), TMP_FILE_SUFFIX).toFile();
+        errorTempFile.deleteOnExit();
+        pb.redirectError(errorTempFile);
+        File output = commandLine.getOutput();
+        File outputTempFile = null;
+        if (output == null) {
+            outputTempFile = Files.createTempFile(getStudioTemporaryFilesRoot(), UUID.randomUUID().toString(), TMP_FILE_SUFFIX).toFile();
+            outputTempFile.deleteOnExit();
+            output = outputTempFile;
+        }
+        pb.redirectOutput(ProcessBuilder.Redirect.appendTo(output));
+        // Start process
+        Process p = pb.start();
+        try {
+			// Wait for the process to finish, up to gitProcWaitForTimeoutSecs
+			boolean exited = p.waitFor(gitProcWaitForTimeoutSecs, TimeUnit.SECONDS);
+			if (!exited) {
+				handleProcessTimeout(p, directory.getAbsolutePath(), output, errorTempFile);
+			}
+
+			int exitValue = p.exitValue();
+			if (exitValue != 0) {
+				handleErrorExitValue(directory.getAbsolutePath(), commandLine.getExceptionResolver(), p, output, errorTempFile);
+			}
+
+            logger.debug("Git command '{}' successfully executed on '{}'", commandLine, directory);
+		} finally {
+			FileUtils.deleteQuietly(outputTempFile);
+			FileUtils.deleteQuietly(errorTempFile);
+			if (p.isAlive()) {
+				// Destroy process
+				destroyProcess(p);
+			}
+		}
+    }
+
+    private void handleErrorExitValue(String directory, GitCliOutputExceptionResolver exceptionResolver,
+                                      Process p, File stdOutFile, File stdErrFile) throws IOException {
+        int exitValue = p.exitValue();
+        String errorOutput = readFileFirstBytes(stdErrFile);
+        String stdOutput = readFileFirstBytes(stdOutFile);
         String errorMessage = format("Git command failed with exit value '%s' on '%s':\n\nSTDOUT: '%s'\nSTDERR: '%s'", exitValue, directory, stdOutput, errorOutput);
         logger.debug(errorMessage);
 
         throw Optional
-                .ofNullable(exceptionResolver.resolveException(exitValue, errorOutput))
+				.ofNullable(exceptionResolver.resolveException(exitValue, errorOutput))
                 .or(() -> Optional.ofNullable(exceptionResolver.resolveException(exitValue, stdOutput)))
                 .orElse(new GitCliOutputException(exitValue, errorMessage));
     }
 
-    private void handleProcessTimeout(Process p, String directory, InputStream processInputStream, InputStream processErrorStream) throws IOException {
-        // Read available bytes, avoiding blocking
-        String stdOutput = new String(processInputStream.readNBytes(processInputStream.available()));
-        String errorOutput = new String(processErrorStream.readNBytes(processErrorStream.available()));
+    private void handleProcessTimeout(Process p, String directory, File stdOutFile, File stdErrFile) throws IOException {
+        String stdOutput = readFileFirstBytes(stdOutFile);
+        String errorOutput = readFileFirstBytes(stdErrFile);
         destroyProcess(p);
         String errorMessage = format("Timeout while waiting for git command to exit on '%s'\nSTDOUT: '%s'\nSTDERR: '%s'", directory, stdOutput, errorOutput);
         logger.debug(errorMessage);
@@ -174,18 +213,18 @@ public class GitCli {
      * @param directory the directory to check
      * @throws GitCliException if the directory does not exist or is not a Git repository
      */
-    private static void checkGitDirectory(final String directory) throws GitCliException {
-        if (Files.notExists(Paths.get(directory))) {
+    private static void checkGitDirectory(final File directory) throws GitCliException {
+        if (Files.notExists(directory.toPath())) {
             throw new GitCliException(format("Directory '%s' does not exist", directory));
         }
-        if (Files.notExists(Paths.get(directory, ".git"))) {
+        if (Files.notExists(directory.toPath().resolve(".git"))) {
             throw new GitCliException(format("Directory '%s' is not a Git repository", directory));
         }
     }
 
-    public void add(String directory, String... paths) throws GitCliException {
+    public void add(File directory, String... paths) throws GitCliException {
         try {
-            executeGitCommand(directory, new GitCommandLine("add", paths));
+            executeGitCommand(new GitCommandLine(directory, "add", paths));
         } catch (Exception e) {
             throw new GitCliException("Git add failed on directory " + directory + " for paths " +
                     ArrayUtils.toString(paths), e);
@@ -196,32 +235,33 @@ public class GitCli {
      * Remove the given paths from the index and discard changes
      * @param directory the git repository directory
      * @param paths the paths to restore
-     * @return the output of the git restore command
      */
-    public String restore(String directory, String... paths) throws GitCliException {
-        GitCommandLine restoreCl = new GitCommandLine("restore");
+    public void restore(File directory, String... paths) throws GitCliException {
+        GitCommandLine restoreCl = new GitCommandLine(directory, "restore");
         restoreCl.addParam("--source=HEAD");
         restoreCl.addParam("--staged");
         restoreCl.addParam("--worktree");
         restoreCl.addParams(paths);
         try {
-            return StringUtils.trim(executeGitCommand(directory, restoreCl));
+            executeGitCommand(restoreCl);
         } catch (Exception e) {
             throw new GitCliException(format("Git restore failed on directory '%s' for paths %s", directory, ArrayUtils.toString(paths)), e);
         }
     }
 
-    public String commit(String directory, String author, String message, String... paths) throws GitCliException {
-        GitCommandLine commitCl = new GitCommandLine("commit");
-        GitCommandLine revParseCl = new GitCommandLine("rev-parse", "HEAD");
+    public String commit(File directory, String author, String message, String... paths) throws GitCliException {
+        GitCommandLine commitCl = new GitCommandLine(directory, "commit");
+        GitCommandLine revParseCl = new GitCommandLine(directory, "rev-parse", "HEAD");
 
         commitCl.addOption("--author", author);
         commitCl.addOption("--message", message);
         commitCl.addParams(paths);
 
+        commitCl.setExceptionResolver(COMMIT_EX_RESOLVER);
+
         try {
-            executeGitCommand(directory, commitCl, COMMIT_EX_RESOLVER);
-            return StringUtils.trim(executeGitCommand(directory, revParseCl));
+            executeGitCommand(commitCl);
+            return executeShortOutputGitCommand(revParseCl);
         } catch (Exception e) {
             throw new GitCliException("Git commit failed on directory " + directory + " for paths " +
                     ArrayUtils.toString(paths), e);
@@ -235,13 +275,13 @@ public class GitCli {
      * @return true if the repository is clean, false otherwise
      * @throws GitCliException if the git status command fails
      */
-    public boolean isRepoClean(String directory) throws GitCliException {
-        GitCommandLine statusCl = new GitCommandLine("status");
+    public boolean isRepoClean(File directory) throws GitCliException {
+        GitCommandLine statusCl = new GitCommandLine(directory, "status");
         // The --porcelain option is a short version specifically for scripts
         statusCl.addParam("--porcelain");
 
         try {
-            String result = executeGitCommand(directory, statusCl, DEFAULT_EX_RESOLVER);
+            String result = executeShortOutputGitCommand(statusCl);
 
             // No result means there's no changes, so the repo is clean
             return StringUtils.isEmpty(result);
@@ -253,29 +293,28 @@ public class GitCli {
     /**
      * Git reset --hard
      *
-     * @param repoPath the git repository directory
-     * @return the output of the git reset command
+     * @param repoDir the git repository directory
      * @throws GitCliException if the git reset command fails
      */
-    public String resetHard(String repoPath) throws GitCliException {
-        GitCommandLine resetCl = new GitCommandLine("reset", "--hard");
+    public void resetHard(File repoDir) throws GitCliException {
+        GitCommandLine resetCl = new GitCommandLine(repoDir, "reset", "--hard");
         try {
-            return StringUtils.trim(executeGitCommand(repoPath, resetCl));
+            executeGitCommand(resetCl);
         } catch (Exception e) {
-            throw new GitCliException("Git reset --hard failed on directory " + repoPath, e);
+            throw new GitCliException("Git reset --hard failed on directory " + repoDir.getAbsolutePath(), e);
         }
     }
 
     /**
      * Git clean (optionally -f)
      *
-     * @param repoPath  the git repository directory
+     * @param repoDir  the git repository directory
      * @param force     true to force clean
      * @param recursive true to clean directories recursively
      * @throws GitCliException if the git clean command fails
      */
-    public void clean(String repoPath, boolean force, boolean recursive) throws GitCliException {
-        GitCommandLine cleanCl = new GitCommandLine("clean");
+    public void clean(File repoDir, boolean force, boolean recursive) throws GitCliException {
+        GitCommandLine cleanCl = new GitCommandLine(repoDir, "clean");
         if (force) {
             cleanCl.addParam("-f");
         }
@@ -283,22 +322,26 @@ public class GitCli {
             cleanCl.addParam("-d");
         }
         try {
-            executeGitCommand(repoPath, cleanCl);
+            executeGitCommand(cleanCl);
         } catch (Exception e) {
-            throw new GitCliException("Git clean failed on directory " + repoPath, e);
+            throw new GitCliException("Git clean failed on directory " + repoDir.getAbsolutePath(), e);
         }
     }
 
     protected class GitCommandLine extends ArrayList<String> {
+        private final File directory;
+        private File input;
+        private File output;
+        private GitCliOutputExceptionResolver exceptionResolver = DEFAULT_EX_RESOLVER;
 
-        public GitCommandLine(String command) {
+        public GitCommandLine(final File directory, final String command) {
+            this.directory = directory;
             add(gitProcName);
             add(command);
         }
 
-        public GitCommandLine(String command, String... params) {
-            add(gitProcName);
-            add(command);
+        public GitCommandLine(final File directory, String command, String... params) {
+            this(directory, command);
             addParams(params);
         }
 
@@ -319,6 +362,33 @@ public class GitCli {
             addParam("\"" + optValue + "\"");
         }
 
+        public File getDirectory() {
+            return directory;
+        }
+
+        public File getInput() {
+            return input;
+        }
+
+        public void setInput(File input) {
+            this.input = input;
+        }
+
+        public File getOutput() {
+            return output;
+        }
+
+        public void setOutput(File output) {
+            this.output = output;
+        }
+
+        public GitCliOutputExceptionResolver getExceptionResolver() {
+            return exceptionResolver;
+        }
+
+        public void setExceptionResolver(GitCliOutputExceptionResolver exceptionResolver) {
+            this.exceptionResolver = exceptionResolver;
+        }
     }
 
 }

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -97,6 +97,8 @@ studio.repo.git.cli.process.name: git
 studio.repo.git.cli.process.waitForTimeout: 300
 # Timeout in seconds when waiting for the Git CLI process to finish after destroying the process forcibly
 studio.repo.git.cli.process.destroy.waitForTimeout: 60
+# Max number of bytes to read from the Git CLI process output (longer outputs will need to read the output file)
+studio.repo.git.cli.process.maxOutputBytes: 1000
 
 ##################################################
 ##           DB Sync from Repository            ##

--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -939,6 +939,8 @@
                          value="#{studioConfiguration.getProperty('studio.repo.git.cli.process.waitForTimeout')}"/>
         <constructor-arg name="gitProcDestroyWaitForTimeoutSecs"
                          value="#{studioConfiguration.getProperty('studio.repo.git.cli.process.destroy.waitForTimeout')}"/>
+        <constructor-arg name="maxProcessOutputBytes"
+                         value="#{studioConfiguration.getProperty('studio.repo.git.cli.process.maxOutputBytes')}"/>
     </bean>
 
     <bean id="studio.gitRepositoryHelper" class="org.craftercms.studio.api.v2.utils.GitRepositoryHelper">


### PR DESCRIPTION
Redirect command output to files to prevent process locking when there are large outputs
Update GitCli to read a max number of bytes from process output. Refactor to reduce number of 'execute' methods
https://github.com/craftercms/craftercms/issues/7939