### PR TITLE
Modified response in content/item_history endpoint yaml

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -5632,7 +5632,7 @@ paths:
                                 properties:
                                     response:
                                         $ref: '#/components/schemas/ApiResponse'
-                                    history:
+                                    items:
                                         type: array
                                         items:
                                             $ref: '#/components/schemas/ItemVersion'


### PR DESCRIPTION
Modified response in content/item_history endpoint yaml to adapt it to the recent changes in the backend. 

Reference ticket is:

https://github.com/craftersoftware/craftercms/issues/1123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
  - The response for the `/api/2/content/item_history` endpoint now returns version history under the property `items` instead of `history`. The structure and data remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->