### PR TITLE
Git global config updates tweaks

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
@@ -67,8 +67,8 @@ public interface StudioConfiguration {
     String REPO_SYNC_EVENT_DELAY_MILLIS = "studio.repo.sync.event.delayMillis";
     String REPO_SYNC_EVENT_MAX_RESET_COUNT = "studio.repo.sync.event.maxResets";
 
-    String DB_CLUSTER_GIT_PRUNE_PACK_EXPIRE = "studio.repo.gc.prunePackExpire";
-    String DB_CLUSTER_GIT_AUTO_PACK_LIMIT = "studio.repo.gc.autoPackLimit";
+	String REPO_GC_PRUNE_PACK_EXPIRE = "studio.repo.gc.prunePackExpire";
+	String REPO_GC_AUTO_PACK_LIMIT = "studio.repo.gc.autoPackLimit";
 
     /** Database */
     String DB_DRIVER = "studio.db.driver";

--- a/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/StudioConfiguration.java
@@ -67,6 +67,7 @@ public interface StudioConfiguration {
     String REPO_SYNC_EVENT_DELAY_MILLIS = "studio.repo.sync.event.delayMillis";
     String REPO_SYNC_EVENT_MAX_RESET_COUNT = "studio.repo.sync.event.maxResets";
 
+	String REPO_GIT_GLOBAL_CONFIG_ENABLED = "studio.repo.git.global.update.enabled";
 	String REPO_GC_PRUNE_PACK_EXPIRE = "studio.repo.gc.prunePackExpire";
 	String REPO_GC_AUTO_PACK_LIMIT = "studio.repo.gc.autoPackLimit";
 

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
@@ -28,8 +28,8 @@ import org.springframework.core.annotation.Order;
 import java.beans.ConstructorProperties;
 import java.io.IOException;
 
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.DB_CLUSTER_GIT_AUTO_PACK_LIMIT;
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.DB_CLUSTER_GIT_PRUNE_PACK_EXPIRE;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_GC_AUTO_PACK_LIMIT;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_GC_PRUNE_PACK_EXPIRE;
 import static org.eclipse.jgit.lib.ConfigConstants.*;
 import static org.opensearch.core.common.Strings.isEmpty;
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
@@ -54,8 +54,8 @@ public class GitStartupConfig {
 		StoredConfig globalConfig = null;
 		try {
 			globalConfig = SystemReader.getInstance().getUserConfig();
-			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_PRUNEPACKEXPIRE, DB_CLUSTER_GIT_PRUNE_PACK_EXPIRE);
-			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, DB_CLUSTER_GIT_AUTO_PACK_LIMIT);
+			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_PRUNEPACKEXPIRE, REPO_GC_PRUNE_PACK_EXPIRE);
+			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, REPO_GC_AUTO_PACK_LIMIT);
 		} catch (ConfigInvalidException e) {
 			logger.error("Error reading git user configuration", e);
 		} catch (IOException e) {

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
@@ -28,8 +28,7 @@ import org.springframework.core.annotation.Order;
 import java.beans.ConstructorProperties;
 import java.io.IOException;
 
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_GC_AUTO_PACK_LIMIT;
-import static org.craftercms.studio.api.v2.utils.StudioConfiguration.REPO_GC_PRUNE_PACK_EXPIRE;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.*;
 import static org.eclipse.jgit.lib.ConfigConstants.*;
 import static org.opensearch.core.common.Strings.isEmpty;
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
@@ -51,12 +50,20 @@ public class GitStartupConfig {
 	@Order(HIGHEST_PRECEDENCE)
 	@EventListener(CleanupRepositoriesEvent.class)
 	public void onStartup() {
+		boolean enabled = studioConfiguration.getProperty(REPO_GIT_GLOBAL_CONFIG_ENABLED, Boolean.class, true);
+		if (!enabled) {
+			logger.info("Global Git config updates disabled by configuration");
+			return;
+		}
+
 		StoredConfig globalConfig = null;
 		try {
 			globalConfig = SystemReader.getInstance().getUserConfig();
-			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_PRUNEPACKEXPIRE, REPO_GC_PRUNE_PACK_EXPIRE);
-			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, REPO_GC_AUTO_PACK_LIMIT);
-			globalConfig.save();
+			boolean hasChanges = setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_PRUNEPACKEXPIRE, REPO_GC_PRUNE_PACK_EXPIRE);
+			hasChanges |= setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, REPO_GC_AUTO_PACK_LIMIT);
+			if (hasChanges) {
+				globalConfig.save();
+			}
 			logger.info("Git global configuration updated successfully.");
 		} catch (ConfigInvalidException e) {
 			logger.error("Error reading git user configuration", e);
@@ -74,15 +81,16 @@ public class GitStartupConfig {
 	 * @param studioConfigProperty the property in the studio configuration to read the value from
 	 * @throws IOException if there is an error saving the git configuration
 	 */
-	protected void setProperty(StoredConfig config, String section, String property, String studioConfigProperty) throws IOException {
+	protected boolean setProperty(StoredConfig config, String section, String property, String studioConfigProperty) throws IOException {
 		String value = studioConfiguration.getProperty(studioConfigProperty);
 		if (isEmpty(value)) {
 			logger.debug("Git '{}' is not set, skipping configuration.", studioConfigProperty);
-			return;
+			return false;
 		}
 		logger.debug("Setting '{}.{}'  to '{}'", section, property, value);
 		config.setString(section, null, property, value);
 		logger.info("Git '{}.{}' set to '{}'", section, property, value);
+		return true;
 	}
 
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitStartupConfig.java
@@ -56,6 +56,8 @@ public class GitStartupConfig {
 			globalConfig = SystemReader.getInstance().getUserConfig();
 			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_PRUNEPACKEXPIRE, REPO_GC_PRUNE_PACK_EXPIRE);
 			setProperty(globalConfig, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, REPO_GC_AUTO_PACK_LIMIT);
+			globalConfig.save();
+			logger.info("Git global configuration updated successfully.");
 		} catch (ConfigInvalidException e) {
 			logger.error("Error reading git user configuration", e);
 		} catch (IOException e) {
@@ -80,7 +82,6 @@ public class GitStartupConfig {
 		}
 		logger.debug("Setting '{}.{}'  to '{}'", section, property, value);
 		config.setString(section, null, property, value);
-		config.save();
 		logger.info("Git '{}.{}' set to '{}'", section, property, value);
 	}
 

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -103,6 +103,9 @@ studio.repo.git.cli.process.maxOutputBytes: 1000
 ##################################################
 ##        Git configuration properties          ##
 ##################################################
+# Git config update to following properties is performed on global configuration and might
+# affect unintended repositories. Opt-out of this by setting this property to false.
+studio.repo.git.global.update.enabled: true
 # git gc --auto will consolidate into one the packs older than this value
 # Notice that this property works when the number of packs is greater than gc.autoPackLimit.
 # See https://git-scm.com/docs/git-gc#Documentation/git-gc.txt-gcautoPackLimit


### PR DESCRIPTION
Global config updates opt-out property.
Save git config once after all updates
Rename git config properties to non-cluster related name
https://github.com/craftersoftware/craftercms/issues/1145