### PR TITLE
Move and update API

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -5046,6 +5046,66 @@ paths:
                 '500':
                     $ref: '#/components/responses/InternalServerError'
 
+    /api/2/content/{siteId}/move-and-update:
+        post:
+            tags:
+                - content
+            summary: Move and update content
+            description: 'Required permission "content_write", "content_delete"'
+            operationId: contentMoveAndUpdate
+            parameters:
+                -   name: siteId
+                    in: path
+                    description: Site ID
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                description: parameters for move-and-update content
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                sourcePath:
+                                    type: string
+                                    description: full path to the item to move
+                                targetPath:
+                                    type: string
+                                    description: full path to the target location (including new name)
+                                content:
+                                    type: string
+                                    description: the item content to update
+                            required:
+                                - sourcePath
+                                - targetPath
+                                - content
+            responses:
+                '200':
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    response:
+                                        $ref: '#/components/schemas/ApiResponse'
+                                allOf:
+                                    -   $ref: '#/components/schemas/WriteContentResponse'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '409':
+                    $ref: '#/components/responses/PublishConflict'
+                '500':
+                    $ref: '#/components/responses/InternalServerError'
+
 
     /api/2/content/{siteId}/revert:
         post:

--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -5046,7 +5046,7 @@ paths:
                 '500':
                     $ref: '#/components/responses/InternalServerError'
 
-    /api/2/content/{siteId}/move-and-update:
+    /api/2/content/{siteId}/move_and_update:
         post:
             tags:
                 - content
@@ -5061,7 +5061,7 @@ paths:
                     schema:
                         type: string
             requestBody:
-                description: parameters for move-and-update content
+                description: parameters for move_and_update content
                 required: true
                 content:
                     application/json:

--- a/src/main/java/org/craftercms/studio/api/v2/service/content/ContentService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/content/ContentService.java
@@ -286,6 +286,16 @@ public interface ContentService {
 	PasteContentResult moveToParentPath(String siteId, String sourcePath, String targetParent)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException;
 
+	/**
+	 * Move content from sourcePath to targetPath and update the content in a single operation.
+	 *
+	 * @param siteId     the site id
+	 * @param sourcePath the source path of the content to move
+	 * @param targetPath the target path where the content will be moved to
+	 * @param content    the content to write at the target path
+	 * @return {@link WriteContentResult} object containing the affected paths
+	 */
+	WriteContentResult moveAndUpdate(String siteId, String sourcePath, String targetPath, String content) throws AuthenticationException, ServiceLayerException;
 
 	/**
 	 * Returns content wrapped as a {@link Resource} instance

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
@@ -305,6 +305,16 @@ public class ContentController {
 		return result;
 	}
 
+	@PostMapping(value = MOVE_AND_UPDATE, consumes = APPLICATION_JSON_VALUE)
+	public Result moveAndUpdate(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody MoveAndUpdateRequestBody requestBody)
+			throws AuthenticationException, ServiceLayerException {
+		UnwrappedResult<WriteContentResult> result = UnwrappedResult.of(
+				contentService.moveAndUpdate(siteId, requestBody.getSourcePath(), requestBody.getTargetPath(), requestBody.getContent())
+		);
+		result.setResponse(OK);
+		return result;
+	}
+
 	@GetMapping(value = ITEM_HISTORY)
 	public ResultList<ItemVersion> getHistory(@ValidSiteId @RequestParam(value = REQUEST_PARAM_SITEID) String siteId,
 											  @ValidExistingContentPath @RequestParam(value = REQUEST_PARAM_PATH) String path) throws ServiceLayerException {

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/RequestMappingConstants.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/RequestMappingConstants.java
@@ -62,7 +62,7 @@ public final class RequestMappingConstants {
 	public static final String GET_CONTENT_BY_COMMIT_ID = "/get_content_by_commit_id";
 	public static final String RENAME = "/rename";
 	public static final String MOVE = SITE_ID + "/move";
-	public static final String MOVE_AND_UPDATE = SITE_ID + "/move-and-update";
+	public static final String MOVE_AND_UPDATE = SITE_ID + "/move_and_update";
 	public static final String REVERT = SITE_ID + "/revert";
 	public static final String ITEM_HISTORY = "/item_history";
 

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/RequestMappingConstants.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/RequestMappingConstants.java
@@ -62,6 +62,7 @@ public final class RequestMappingConstants {
 	public static final String GET_CONTENT_BY_COMMIT_ID = "/get_content_by_commit_id";
 	public static final String RENAME = "/rename";
 	public static final String MOVE = SITE_ID + "/move";
+	public static final String MOVE_AND_UPDATE = SITE_ID + "/move-and-update";
 	public static final String REVERT = SITE_ID + "/revert";
 	public static final String ITEM_HISTORY = "/item_history";
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
@@ -215,6 +215,16 @@ public class ContentServiceImpl implements ContentService {
 	}
 
 	@Override
+	@RequireSiteReady
+	@ValidateAction(type = Type.MOVE)
+	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
+	public WriteContentResult moveAndUpdate(@SiteId String siteId, @ActionSourcePath String sourcePath,
+											@ActionTargetPath String targetPath, String content)
+			throws AuthenticationException, ServiceLayerException {
+		return contentServiceInternal.moveAndUpdate(siteId, sourcePath, targetPath, content);
+	}
+
+	@Override
 	@Valid
 	@RequireSiteReady
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
@@ -190,6 +190,7 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@RequireSiteReady
+	@ValidateAction(type = Type.RENAME)
 	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
 	public void renameContent(@SiteId String site,
 							  @ContentPath String path, String name)
@@ -244,6 +245,7 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@RequireSiteReady
+	@ValidateAction(type = Type.CREATE)
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_WRITE)
 	public WriteContentResult write(@SiteId String siteId, @ContentPath String path, InputStream content)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
@@ -262,6 +264,7 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@RequireSiteReady
+	@ValidateAction(type = COPY)
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public PasteContentResult duplicate(@SiteId String siteId, @ContentPath String sourcePath) throws ServiceLayerException, AuthenticationException {
 		return contentServiceInternal.duplicate(siteId, sourcePath);
@@ -269,6 +272,7 @@ public class ContentServiceImpl implements ContentService {
 
 	@Override
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_WRITE)
+	@ValidateAction(type = Type.EDIT)
 	public void revert(String siteId, String path, String commitId) throws ServiceLayerException {
 		contentServiceInternal.revert(siteId, path, commitId);
 	}

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentServiceImpl.java
@@ -104,9 +104,9 @@ public class ContentServiceImpl implements ContentService {
 											   @ProtectedResourceId(PATH_RESOURCE_ID) String path, String locale,
 											   String keyword, List<String> systemTypes, List<String> excludes,
 											   String sortStrategy, String order, int offset, int limit)
-		throws ServiceLayerException, UserNotFoundException {
+			throws ServiceLayerException, UserNotFoundException {
 		return contentServiceInternal.getChildrenByPath(siteId, path, locale, keyword, systemTypes, excludes,
-			sortStrategy, order, offset, limit);
+				sortStrategy, order, offset, limit);
 	}
 
 	@Override
@@ -115,7 +115,7 @@ public class ContentServiceImpl implements ContentService {
 	public GetChildrenByPathsBulkResult getChildrenByPaths(@SiteId String siteId,
 														   @ProtectedResourceId(PATH_LIST_RESOURCE_ID) List<String> paths,
 														   Map<String, PathParams> pathParams)
-		throws ServiceLayerException, UserNotFoundException {
+			throws ServiceLayerException, UserNotFoundException {
 		return contentServiceInternal.getChildrenByPaths(siteId, paths, pathParams);
 	}
 
@@ -124,7 +124,7 @@ public class ContentServiceImpl implements ContentService {
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public Item getItem(@SiteId String siteId,
 						@ProtectedResourceId(PATH_RESOURCE_ID) String path, boolean flatten)
-		throws SiteNotFoundException, ContentNotFoundException {
+			throws SiteNotFoundException, ContentNotFoundException {
 		try {
 			return contentServiceInternal.getItem(siteId, path, flatten);
 		} catch (PathNotFoundException e) {
@@ -138,7 +138,7 @@ public class ContentServiceImpl implements ContentService {
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public Document getItemDescriptor(@SiteId String siteId,
 									  @ProtectedResourceId(PATH_RESOURCE_ID) String path, boolean flatten)
-		throws SiteNotFoundException, ContentNotFoundException {
+			throws SiteNotFoundException, ContentNotFoundException {
 		return contentServiceInternal.getItemDescriptor(siteId, path, flatten);
 	}
 
@@ -147,7 +147,7 @@ public class ContentServiceImpl implements ContentService {
 	@RequireContentExists
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_GET_CHILDREN)
 	public ContentItem getItemByPath(@SiteId String siteId, @ContentPath String path, boolean preferContent)
-		throws ServiceLayerException, UserNotFoundException {
+			throws ServiceLayerException, UserNotFoundException {
 		return contentServiceInternal.getItemByPath(siteId, path, preferContent);
 	}
 
@@ -157,7 +157,7 @@ public class ContentServiceImpl implements ContentService {
 	public List<ContentItem> getContentItemsByPath(@SiteId String siteId,
 												   @ProtectedResourceId(PATH_LIST_RESOURCE_ID) List<String> paths,
 												   boolean preferContent)
-		throws ServiceLayerException, UserNotFoundException {
+			throws ServiceLayerException, UserNotFoundException {
 		return contentServiceInternal.getContentItemsByPath(siteId, paths, preferContent);
 	}
 
@@ -166,7 +166,7 @@ public class ContentServiceImpl implements ContentService {
 	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
 	public void lockContent(@SiteId String siteId,
 							@ProtectedResourceId(PATH_RESOURCE_ID) String path)
-		throws UserNotFoundException, ServiceLayerException {
+			throws UserNotFoundException, ServiceLayerException {
 		contentServiceInternal.lockContent(siteId, path);
 	}
 
@@ -175,7 +175,7 @@ public class ContentServiceImpl implements ContentService {
 	@HasPermission(type = PermissionOrOwnership.class, action = PERMISSION_ITEM_UNLOCK)
 	public void unlockContent(@SiteId String siteId,
 							  @ProtectedResourceId(PATH_RESOURCE_ID) String path)
-		throws ContentNotFoundException, SiteNotFoundException {
+			throws ContentNotFoundException, SiteNotFoundException {
 		contentServiceInternal.unlockContent(siteId, path);
 	}
 
@@ -193,8 +193,8 @@ public class ContentServiceImpl implements ContentService {
 	@ValidateAction(type = Type.RENAME)
 	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
 	public void renameContent(@SiteId String site,
-							  @ContentPath String path, String name)
-		throws ServiceLayerException, UserNotFoundException, ValidationException, AuthenticationException {
+							  @ContentPath @ActionTargetPath String path, String name)
+			throws ServiceLayerException, UserNotFoundException, ValidationException, AuthenticationException {
 		contentServiceInternal.renameContent(site, path, name);
 	}
 
@@ -203,7 +203,7 @@ public class ContentServiceImpl implements ContentService {
 	@ValidateAction(type = Type.MOVE)
 	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
 	public PasteContentResult move(@SiteId String siteId, @ActionSourcePath String sourcePath, @ActionTargetPath @ContentPath String targetPath)
-		throws ServiceLayerException, UserNotFoundException, AuthenticationException {
+			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		return contentServiceInternal.move(siteId, sourcePath, targetPath);
 	}
 
@@ -211,7 +211,8 @@ public class ContentServiceImpl implements ContentService {
 	@RequireSiteReady
 	@ValidateAction(type = Type.MOVE)
 	@HasPermission(type = CompositePermission.class, action = PERMISSION_CONTENT_WRITE)
-	public PasteContentResult moveToParentPath(String siteId, String sourcePath, String targetParent) throws ServiceLayerException, UserNotFoundException, AuthenticationException {
+	public PasteContentResult moveToParentPath(String siteId, @ActionSourcePath String sourcePath, @ActionTargetPath String targetParent)
+			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		return contentServiceInternal.moveToParentPath(siteId, sourcePath, targetParent);
 	}
 
@@ -231,7 +232,7 @@ public class ContentServiceImpl implements ContentService {
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public Resource getContentAsResource(@SiteId String site,
 										 @ValidateSecurePathParam @ContentPath String path)
-		throws ContentNotFoundException {
+			throws ContentNotFoundException {
 		return contentServiceInternal.getContentAsResource(site, path);
 	}
 
@@ -247,7 +248,7 @@ public class ContentServiceImpl implements ContentService {
 	@RequireSiteReady
 	@ValidateAction(type = Type.CREATE)
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_WRITE)
-	public WriteContentResult write(@SiteId String siteId, @ContentPath String path, InputStream content)
+	public WriteContentResult write(@SiteId String siteId, @ContentPath @ActionTargetPath String path, InputStream content)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		return contentServiceInternal.write(siteId, path, content);
 	}
@@ -273,7 +274,7 @@ public class ContentServiceImpl implements ContentService {
 	@Override
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_WRITE)
 	@ValidateAction(type = Type.EDIT)
-	public void revert(String siteId, String path, String commitId) throws ServiceLayerException {
+	public void revert(@SiteId String siteId, @ActionTargetPath @ContentPath String path, String commitId) throws ServiceLayerException {
 		contentServiceInternal.revert(siteId, path, commitId);
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -19,6 +19,7 @@ package org.craftercms.studio.impl.v2.service.content.internal;
 import com.google.common.collect.Lists;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.craftercms.commons.rest.parameters.SortField;
 import org.craftercms.commons.security.exception.ActionDeniedException;
@@ -103,6 +104,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Set.of;
@@ -1546,7 +1548,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		logger.debug("Rename path '{}' to new name '{}' for site '{}'", path, name, siteId);
 		String parentPath = getParentUrl(path);
 		String targetPath = parentPath + FILE_SEPARATOR + name;
-		doMove(siteId, path, targetPath, null);
+		doMove(siteId, path, targetPath, null, null);
 	}
 
 	/**
@@ -1578,13 +1580,18 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	@Override
 	public PasteContentResult move(final String siteId, final String sourcePath, final String targetPath)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
-		return doMove(siteId, sourcePath, targetPath, null);
+		return doMove(siteId, sourcePath, targetPath, null, null);
 	}
 
 	@Override
 	public PasteContentResult moveToParentPath(String siteId, String sourcePath, String targetParent) throws ServiceLayerException, AuthenticationException {
 		PastedPath pastedPath = constructNewPathForCutCopy(siteId, sourcePath, targetParent);
-		return doMove(siteId, sourcePath, pastedPath.path, pastedPath.newLabel);
+		return doMove(siteId, sourcePath, pastedPath.path, pastedPath.newLabel, null);
+	}
+
+	@Override
+	public WriteContentResult moveAndUpdate(String siteId, String sourcePath, String targetPath, String content) throws AuthenticationException, ServiceLayerException {
+		return doMove(siteId, sourcePath, targetPath, null, () -> IOUtils.toInputStream(content, UTF_8));
 	}
 
 	/**
@@ -1596,7 +1603,9 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 * @param newLabel the new label for the content
 	 * @return the result of the move operation
 	 */
-	protected PasteContentResult doMove(final String siteId, final String from, final String to, final String newLabel) throws ServiceLayerException, AuthenticationException {
+	protected PasteContentResult doMove(final String siteId, final String from, final String to, final String newLabel,
+										final ThrowingSupplier<InputStream> newContent)
+			throws ServiceLayerException {
 		if (!contentExists(siteId, from)) {
 			throw new ContentNotFoundException(from, siteId, format("Content not found at path '%s' in site '%s'", from, siteId));
 		}
@@ -1631,7 +1640,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 				if (isDescriptor(sourcePath)) {
 					sourcePathChildren.add(sourcePath);
 				}
-				Collection<LifecycleContent> lifecycleContents = runLifecycleForMove(siteId, sourcePath, targetPath, sourcePathChildren, newLabel);
+				Collection<LifecycleContent> lifecycleContents = runLifecycleForMove(siteId, sourcePath, targetPath, sourcePathChildren, newLabel, newContent);
 				Collection<String> lifecyclePaths = getPathsForSystemProcessing(lifecycleContents);
 				// Set system processing for paths added by the lifecycle
 				trySetSystemProcessing(siteId, subtract(lifecyclePaths, processingPaths));
@@ -1798,14 +1807,18 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 * @throws ServiceLayerException if there is an error running the lifecycle
 	 */
 	protected Collection<LifecycleContent> runLifecycleForMove(String siteId, String sourcePath, String targetPath,
-															   Set<String> sourcePathChildren, String newLabel) throws ServiceLayerException {
+															   Set<String> sourcePathChildren, String newLabel,
+															   ThrowingSupplier<InputStream> newContent) throws ServiceLayerException {
 		ArrayList<LifecycleContent> lifecycleContents = new ArrayList<>(sourcePathChildren.size());
 		try {
 			for (String itemSourcePath : sourcePathChildren) {
 				boolean isRootItem = StringUtils.equals(sourcePath, removeEnd(itemSourcePath, SLASH_INDEX_FILE));
 				String itemTargetPath = movePath(sourcePath, targetPath, itemSourcePath);
+				ThrowingSupplier<InputStream> contentSupplier = isRootItem && newContent != null
+						? newContent
+						: () -> loadContent(siteId, itemSourcePath);
 				lifecycleContents.add(runLifecycle(siteId, itemSourcePath, itemTargetPath,
-						() -> loadContent(siteId, itemSourcePath), RENAME, isRootItem ? newLabel : null));
+						contentSupplier, RENAME, isRootItem ? newLabel : null));
 			}
 		} catch (Exception e) {
 			closeCollection(lifecycleContents);

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -21,6 +21,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.craftercms.commons.entitlements.exception.EntitlementException;
+import org.craftercms.commons.entitlements.model.EntitlementType;
+import org.craftercms.commons.entitlements.validator.EntitlementValidator;
 import org.craftercms.commons.rest.parameters.SortField;
 import org.craftercms.commons.security.exception.ActionDeniedException;
 import org.craftercms.commons.security.permissions.PermissionEvaluator;
@@ -179,6 +182,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	private final RetryingDatabaseOperationFacade retryingDatabaseOperationFacade;
 	private final ServicesConfig servicesConfig;
 	private final ActivityStreamService activityStreamService;
+	private final EntitlementValidator entitlementValidator;
 
 	@ConstructorProperties({"transactionManager", "studioConfiguration", "siteService",
 			"retryingDatabaseOperationFacade", "publishService",
@@ -186,7 +190,8 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 			"itemDao", "generalLockService", "dependencyService",
 			"contentServiceV1", "contentRepository", "contentLifecycle",
 			"auditService", "assetLifecycle",
-			"servicesConfig", "activityStreamService"})
+			"servicesConfig", "activityStreamService",
+			"entitlementValidator"})
 	public ContentServiceInternalImpl(PlatformTransactionManager transactionManager, StudioConfiguration studioConfiguration,
 									  SitesService siteService,
 									  RetryingDatabaseOperationFacade retryingDatabaseOperationFacade, PublishService publishService,
@@ -197,7 +202,8 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 									  org.craftercms.studio.api.v1.service.content.ContentService contentServiceV1,
 									  GitContentRepository contentRepository, ContentLifecycle contentLifecycle,
 									  AuditService auditService, ContentLifecycle assetLifecycle,
-									  ServicesConfig servicesConfig, ActivityStreamService activityStreamService) {
+									  ServicesConfig servicesConfig, ActivityStreamService activityStreamService,
+									  EntitlementValidator entitlementValidator) {
 		this.transactionManager = transactionManager;
 		this.studioConfiguration = studioConfiguration;
 		this.siteService = siteService;
@@ -216,6 +222,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		this.assetLifecycle = assetLifecycle;
 		this.servicesConfig = servicesConfig;
 		this.activityStreamService = activityStreamService;
+		this.entitlementValidator = entitlementValidator;
 	}
 
 	@Override
@@ -617,7 +624,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	protected PasteContentResult doCopy(final String siteId, final String from,
 										final String initialTargetPath, final Set<String> itemPaths,
 										final LifecycleOperation operation)
-			throws ServiceLayerException, AuthenticationException {
+			throws ServiceLayerException {
 		PastedPath pastedPath = constructNewPathForCutCopy(siteId, from, initialTargetPath);
 		String to = pastedPath.path;
 		if (!contentExists(siteId, from)) {
@@ -852,6 +859,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 			// Source path is null since copy does not affect the source path
 			validateLifecycleResults(siteId, null, targetPath, getMoveOrCopyWorkflowAffectedPaths(targetPath, lifecycleItems));
 			Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, sourceItemPaths, lifecycleItems.values(), operation);
+			validateEntitlements(operationsByPath);
 			Set<String> newFolders = getMissingFoldersForCopyOrMove(siteId, lifecycleItems.values());
 			Map<String, ContentWriteItem> additionalItems = calculateAdditionalItemsForCopyOrMove(lifecycleItems);
 			additionalItems.putAll(dependencies);
@@ -989,11 +997,10 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 											   final LifecycleContent lifecycleContent)
 			throws ServiceLayerException, UserNotFoundException, AuthenticationException {
 		Map<String, ContentLifecycleItem> lifecycleResultItems = lifecycleContent.getItems();
-		Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, lifecycleContent.getRepoPath(),
+		Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, List.of(lifecycleContent.getRepoPath()),
 				lifecycleResultItems.values(), lifecycleContent.getOperation());
+		validateEntitlements(operationsByPath);
 		Set<String> missingFolders = getMissingFolders(siteId, operationsByPath);
-		// TODO: Consider creating the commit in a temporary branch and merge after db updates complete
-		// 		successfully
 		// Write to the repository and commit.
 		String commitId = contentRepository.writeContent(siteId, lifecycleResultItems.values(), missingFolders);
 		if (isEmpty(commitId)) {
@@ -1012,6 +1019,29 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		// Audit write operation
 		insertContentAudit(siteId, null, path, lifecycleContent.getOperation(), writeContentResult);
 		return writeContentResult;
+	}
+
+	/**
+	 * Validate the entitlements for the write operation
+	 * It counts the number of new items being created and validates the entitlement for that number of items
+	 * minus the number of items being deleted.
+	 *
+	 * @param operationsByPath the map of operations by path
+	 * @throws ServiceLayerException if the entitlement validation fails
+	 */
+	protected void validateEntitlements(Map<String, LifecycleOperation> operationsByPath) throws ServiceLayerException {
+		int netAddedCount = operationsByPath.values().stream()
+				.collect(teeing(
+						filtering(op -> op == NEW || op.isCopy, counting()),
+						filtering(op -> op == DELETE, counting()),
+						(added, deleted) -> added - deleted
+				)).intValue();
+		try {
+			entitlementValidator.validateEntitlement(EntitlementType.ITEM, netAddedCount);
+		} catch (EntitlementException e) {
+			throw new ServiceLayerException(format("Failed to perform write operation to add %s new items due to entitlement validation failure",
+					netAddedCount), e);
+		}
 	}
 
 	/**
@@ -1053,20 +1083,35 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	}
 
 	/**
-	 * Creates a map out of the ContentLifecycleItems, where the key is the path and
-	 * the value is the operation performed
+	 * Overloaded method for non-DELETE operations
 	 */
-	protected @NotNull Map<String, LifecycleOperation> getOperationsByPath(String siteId, String sourcePath,
-																		   Collection<ContentLifecycleItem> resultItems,
-																		   LifecycleOperation mainItemOperation) {
-		return getOperationsByPath(siteId, of(sourcePath), resultItems, mainItemOperation);
-	}
-
 	protected Map<String, LifecycleOperation> getOperationsByPath(String siteId, Collection<String> sourcePaths,
 																  Collection<ContentLifecycleItem> resultItems,
 																  LifecycleOperation mainItemOperation) {
-		// Calculate the operation. This must be done before actually writing to the repository
-		return resultItems.stream()
+		return getOperationsByPath(siteId, emptyList(), sourcePaths, resultItems, mainItemOperation);
+	}
+
+
+	/**
+	 * Creates a map out of the ContentLifecycleItems, where the key is the path and
+	 * the value is the operation performed.
+	 *
+	 * @param siteId            the site id
+	 * @param deletedPaths      the list of paths that are being deleted (applies for DELETE operations)
+	 * @param sourcePaths       the initial user-requested list of paths
+	 * @param resultItems       the result items from the lifecycle processing
+	 * @param mainItemOperation the operation for the main item (e.g. the one that was requested by the user)
+	 * @return a map of path to operation
+	 */
+	protected Map<String, LifecycleOperation> getOperationsByPath(String siteId, Collection<String> deletedPaths,
+																  Collection<String> sourcePaths,
+																  Collection<ContentLifecycleItem> resultItems,
+																  LifecycleOperation mainItemOperation) {
+		Map<String, LifecycleOperation> result = new HashMap<>();
+		// Add the deleted paths first, so they are not overridden by the result items in case
+		// they are added by the lifecycle processing
+		deletedPaths.forEach(p -> result.put(p, DELETE));
+		result.putAll(resultItems.stream()
 				.collect(toMap(ContentWriteItem::repoPath, item -> {
 					if (item.sourcePath() != null && sourcePaths.contains(item.sourcePath())) {
 						// Preserve the operation for the main item
@@ -1076,7 +1121,9 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 						return UPDATE;
 					}
 					return NEW;
-				}));
+				})));
+
+		return result;
 	}
 
 	/**
@@ -1384,7 +1431,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		ArrayList<LifecycleContent> lifecycleContents = new ArrayList<>(paths.size());
 		try {
 			for (String path : paths) {
-				// No delete for assets
+				// No delete lifecycle for assets
 				if (isDescriptor(path)) {
 					Item item = itemService.getItem(siteId, path, false);
 					String contentType = item.getContentTypeId();
@@ -1401,7 +1448,6 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 					siteId), e);
 		}
 		return lifecycleContents;
-
 	}
 
 	protected DeleteContentResult deleteInternal(String siteId, Set<String> userRequestedPaths,
@@ -1411,37 +1457,38 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 		try {
 			Site site = siteService.getSite(siteId);
 			long publishPackageId = 0;
-			Set<String> paths = new HashSet<>(userRequestedPaths.size() + dependencies.size());
-			paths.addAll(userRequestedPaths);
-			paths.addAll(dependencies);
+			Set<String> deletePaths = new HashSet<>(userRequestedPaths.size() + dependencies.size());
+			deletePaths.addAll(userRequestedPaths);
+			deletePaths.addAll(dependencies);
 
 			Map<String, ContentLifecycleItem> additionalItems = lifecycleContents.stream()
 					.flatMap(lifecycleContent -> lifecycleContent.getItems().values()
 							.stream()
-							.filter(item -> !paths.contains(item.repoPath())))
+							.filter(item -> !deletePaths.contains(item.repoPath())))
 					.collect(toMap(ContentLifecycleItem::repoPath, identity()));
 
-			Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, emptyList(), additionalItems.values(), DELETE);
+			Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, deletePaths, emptyList(), additionalItems.values(), DELETE);
+			validateEntitlements(operationsByPath);
 			Set<String> newFolders = additionalItems.values().stream()
 					.flatMap(i -> calculateMissingFolders(siteId, i.repoPath()).stream())
 					.collect(toSet());
 
 			// check and fail if any of the items is part of a publish package
-			assertNotInWorkflow(siteId, paths, false);
-			String commitId = contentRepository.deleteContent(siteId, paths, additionalItems.values(), newFolders);
+			assertNotInWorkflow(siteId, deletePaths, false);
+			String commitId = contentRepository.deleteContent(siteId, deletePaths, additionalItems.values(), newFolders);
 
 			if (contentRepository.publishedRepositoryExists(siteId)) {
 				Set<String> writtenPaths = additionalItems.values().stream()
 						.map(ContentWriteItem::repoPath)
 						.collect(toSet());
-				// Do not publish paths that were not really deleted
+				// Do not publish deletePaths that were not really deleted
 				publishPackageId = publishService.publishDelete(siteId, difference(userRequestedPaths, writtenPaths),
 						difference(dependencies, writtenPaths), publishTitle, publishComment);
 			}
 
 			List<WriteContentResultItem> resultItems = new LinkedList<>();
 			resultItems.addAll(
-					paths.stream()
+					deletePaths.stream()
 							.filter(path -> !additionalItems.containsKey(path))
 							.map(path -> new WriteContentResultItem(path, DELETE, false))
 							.toList());
@@ -1455,7 +1502,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 
 			insertDeleteContentAudit(siteId, deleteResult);
 
-			for (String path : paths) {
+			for (String path : deletePaths) {
 				dependencyService.deleteItemDependencies(siteId, path);
 				dependencyService.invalidateDependencies(siteId, path);
 				itemService.deleteItem(site.getId(), path, true);
@@ -1544,7 +1591,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	}
 
 	@Override
-	public void renameContent(final String siteId, final String path, final String name) throws ServiceLayerException, AuthenticationException {
+	public void renameContent(final String siteId, final String path, final String name) throws ServiceLayerException {
 		logger.debug("Rename path '{}' to new name '{}' for site '{}'", path, name, siteId);
 		String parentPath = getParentUrl(path);
 		String targetPath = parentPath + FILE_SEPARATOR + name;
@@ -1584,13 +1631,13 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	}
 
 	@Override
-	public PasteContentResult moveToParentPath(String siteId, String sourcePath, String targetParent) throws ServiceLayerException, AuthenticationException {
+	public PasteContentResult moveToParentPath(String siteId, String sourcePath, String targetParent) throws ServiceLayerException {
 		PastedPath pastedPath = constructNewPathForCutCopy(siteId, sourcePath, targetParent);
 		return doMove(siteId, sourcePath, pastedPath.path, pastedPath.newLabel, null);
 	}
 
 	@Override
-	public WriteContentResult moveAndUpdate(String siteId, String sourcePath, String targetPath, String content) throws AuthenticationException, ServiceLayerException {
+	public WriteContentResult moveAndUpdate(String siteId, String sourcePath, String targetPath, String content) throws ServiceLayerException {
 		return doMove(siteId, sourcePath, targetPath, null, () -> IOUtils.toInputStream(content, UTF_8));
 	}
 
@@ -1702,7 +1749,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 			Map<String, ContentWriteItem> additionalItems = calculateAdditionalItemsForCopyOrMove(lifecycleItems);
 			// We need to calculate this before the commit
 			Map<String, LifecycleOperation> operationsByPath = getOperationsByPath(siteId, sourcePathChildren, lifecycleItems.values(), RENAME);
-
+			validateEntitlements(operationsByPath);
 			// Commit the changeset
 			String commitId = contentRepository.moveContent(siteId, sourcePath, targetPath, additionalItems.values(), newFolders);
 			if (isEmpty(commitId)) {

--- a/src/main/java/org/craftercms/studio/model/rest/content/MoveAndUpdateRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/content/MoveAndUpdateRequestBody.java
@@ -17,32 +17,19 @@
 package org.craftercms.studio.model.rest.content;
 
 import jakarta.validation.constraints.NotEmpty;
-import org.craftercms.commons.validation.annotations.param.ValidExistingContentPath;
 
 /**
- * Request body for a content write operation
+ * Request body for a move-and-update operation.
  */
-public class WriteContentRequest {
-
-	@NotEmpty
-	@ValidExistingContentPath
-	private String path;
+public class MoveAndUpdateRequestBody extends MoveRequestBody {
 	@NotEmpty
 	private String content;
 
-	public String getContent() {
+	public final String getContent() {
 		return content;
 	}
 
 	public void setContent(final String content) {
 		this.content = content;
-	}
-
-	public String getPath() {
-		return path;
-	}
-
-	public void setPath(final String path) {
-		this.path = path;
 	}
 }

--- a/src/main/java/org/craftercms/studio/model/rest/content/MoveAndUpdateRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/content/MoveAndUpdateRequestBody.java
@@ -19,7 +19,7 @@ package org.craftercms.studio.model.rest.content;
 import jakarta.validation.constraints.NotEmpty;
 
 /**
- * Request body for a move-and-update operation.
+ * Request body for a move_and_update operation.
  */
 public class MoveAndUpdateRequestBody extends MoveRequestBody {
 	@NotEmpty

--- a/src/main/java/org/craftercms/studio/model/rest/content/MoveRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/content/MoveRequestBody.java
@@ -31,19 +31,19 @@ public class MoveRequestBody {
 	@ValidNewContentPath
 	private String targetPath;
 
-	public @NotEmpty @ValidExistingContentPath String getSourcePath() {
+	public String getSourcePath() {
 		return sourcePath;
 	}
 
-	public void setSourcePath(@NotEmpty @ValidExistingContentPath String sourcePath) {
+	public void setSourcePath(String sourcePath) {
 		this.sourcePath = sourcePath;
 	}
 
-	public @NotEmpty @ValidNewContentPath String getTargetPath() {
+	public String getTargetPath() {
 		return targetPath;
 	}
 
-	public void setTargetPath(@NotEmpty @ValidNewContentPath String targetPath) {
+	public void setTargetPath(String targetPath) {
 		this.targetPath = targetPath;
 	}
 }

--- a/src/test/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImplTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImplTest.java
@@ -16,6 +16,9 @@
 
 package org.craftercms.studio.impl.v2.service.content.internal;
 
+import org.craftercms.commons.entitlements.exception.EntitlementException;
+import org.craftercms.commons.entitlements.model.EntitlementType;
+import org.craftercms.commons.entitlements.validator.EntitlementValidator;
 import org.craftercms.commons.security.exception.ActionDeniedException;
 import org.craftercms.commons.security.permissions.PermissionEvaluator;
 import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
@@ -75,13 +78,13 @@ import java.util.*;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.apache.commons.lang3.exception.ExceptionUtils.throwableOfType;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.CONTENT_TYPE_FOLDER;
 import static org.craftercms.studio.api.v2.content.LifecycleContent.LifecycleOperation.*;
 import static org.craftercms.studio.api.v2.utils.StudioUtils.*;
 import static org.craftercms.studio.impl.v1.util.ContentUtils.convertStreamToXml;
 import static org.craftercms.studio.impl.v1.util.ContentUtils.getParentUrl;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -137,6 +140,9 @@ public class ContentServiceInternalImplTest {
 
 	@Mock
 	protected SitesService siteService;
+
+	@Mock
+	protected EntitlementValidator entitlementValidator;
 
 	@InjectMocks
 	@Spy
@@ -727,6 +733,152 @@ public class ContentServiceInternalImplTest {
 				"COMMIT123"));
 	}
 
+	@Test
+	public void testEntitlementsUpdate() throws Exception {
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+		when(contentRepository.writeContent(eq(SITE_ID), anyCollection(), anySet())).thenReturn("commit-id");
+		runInMockStatics(() -> serviceInternal.write(
+				SITE_ID,
+				PATH,
+				contentStream
+		));
+
+		verify(entitlementValidator, times(1)).validateEntitlement(
+				EntitlementType.ITEM,
+				0
+		);
+	}
+
+	@Test
+	public void testEntitlementsCreate() throws Exception {
+		Item parentItem = mock(Item.class);
+		when(parentItem.getId()).thenReturn(123L);
+		when(itemService.getItem(SITE_ID, "/sample", false)).thenReturn(parentItem);
+		when(contentRepository.contentExists(SITE_ID, "/sample")).thenReturn(true);
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+		when(contentRepository.writeContent(eq(SITE_ID), anyCollection(), anySet())).thenReturn("commit-id");
+		runInMockStatics(() -> serviceInternal.write(
+				SITE_ID,
+				NON_EXIST_CONTENT_PATH,
+				contentStream
+		));
+
+		verify(entitlementValidator, times(1)).validateEntitlement(
+				EntitlementType.ITEM,
+				1 // 1 for the new item
+		);
+	}
+
+	@Test
+	public void testEntitlementsCreateMultiple() throws Exception {
+		Item parentItem = mock(Item.class);
+		when(parentItem.getId()).thenReturn(123L);
+		when(itemService.getItem(SITE_ID, "/sample", false)).thenReturn(parentItem);
+		when(contentRepository.contentExists(SITE_ID, "/sample")).thenReturn(true);
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+		when(contentRepository.writeContent(eq(SITE_ID), anyCollection(), anySet())).thenReturn("commit-id");
+
+		doAnswer(a -> {
+			LifecycleContent lifecycleContent = (LifecycleContent) a.getArguments()[1];
+			lifecycleContent.write("/sample/path1", mock(Path.class));
+			lifecycleContent.write("/sample/path2", mock(Path.class));
+			return null;
+		}).when(contentLifecycle).execute(
+				anyString(),
+				any(LifecycleContent.class),
+				any()
+		);
+
+		runInMockStatics(() -> serviceInternal.write(
+				SITE_ID,
+				NON_EXIST_CONTENT_PATH,
+				contentStream
+		));
+
+		verify(entitlementValidator, times(1)).validateEntitlement(
+				EntitlementType.ITEM,
+				3 // 1 (initial create) + 2 (writes)
+		);
+	}
+
+	@Test
+	public void testEntitlementsDeleteAndWrites() throws Exception {
+		String deletePath = "/site/website/page1/index.xml";
+		Item deleteItem = mock(Item.class);
+		Item parentItem = mock(Item.class);
+		when(parentItem.getId()).thenReturn(123L);
+		when(itemService.getItem(SITE_ID, "/sample", false)).thenReturn(parentItem);
+
+		when(itemService.getItem(SITE_ID, deletePath, false)).thenReturn(deleteItem);
+		when(contentRepository.contentExists(SITE_ID, deletePath)).thenReturn(true);
+		when(contentRepository.contentExists(SITE_ID, "/sample")).thenReturn(true);
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+
+		doAnswer(a -> {
+			LifecycleContent lifecycleContent = (LifecycleContent) a.getArguments()[1];
+			lifecycleContent.write("/sample/path1", mock(Path.class));
+			lifecycleContent.write("/sample/path2", mock(Path.class));
+			return null;
+		}).when(contentLifecycle).execute(
+				anyString(),
+				any(LifecycleContent.class),
+				any()
+		);
+
+		runInMockStatics(() -> serviceInternal.deleteContent(
+				SITE_ID,
+				Set.of(deletePath),
+				"Publish title",
+				"Publish comment"
+		));
+
+		verify(entitlementValidator, times(1)).validateEntitlement(
+				EntitlementType.ITEM,
+				1 // -1 (delete) + 2 (writes)
+		);
+	}
+
+	@Test
+	public void testEntitlementsDelete() throws Exception {
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+
+		runInMockStatics(() -> serviceInternal.deleteContent(
+				SITE_ID,
+				Set.of(PATH),
+				"Publish title",
+				"Publish comment"
+		));
+
+		verify(entitlementValidator, times(1)).validateEntitlement(
+				EntitlementType.ITEM,
+				-1 // -1 for delete operation
+		);
+	}
+
+	@Test
+	public void testFailedEntitlementValidationCreate() throws Exception {
+		Item parentItem = mock(Item.class);
+		when(parentItem.getId()).thenReturn(123L);
+		when(itemService.getItem(SITE_ID, "/sample", false)).thenReturn(parentItem);
+		when(contentRepository.contentExists(SITE_ID, "/sample")).thenReturn(true);
+		when(permissionEvaluator.isAllowed(any(), any(), any())).thenReturn(true);
+		when(contentRepository.writeContent(eq(SITE_ID), anyCollection(), anySet())).thenReturn("commit-id");
+
+		doThrow(EntitlementException.class).when(entitlementValidator).validateEntitlement(EntitlementType.ITEM, 1);
+
+		runInMockStatics(() -> {
+			ServiceLayerException exception = assertThrows(ServiceLayerException.class, () -> serviceInternal.write(
+					SITE_ID,
+					NON_EXIST_CONTENT_PATH,
+					contentStream
+			));
+			EntitlementException entitlementException = throwableOfType(exception, EntitlementException.class);
+			assertNotNull("Exception thrown should be EntitlementException", entitlementException);
+		});
+
+		verify(contentRepository, never()).writeContent(eq(SITE_ID), anyCollection(), anySet());
+	}
+
 	/**
 	 * Runs the provided runnable in a mocked static context for DBUtils and SecurityUtils.
 	 *
@@ -749,7 +901,8 @@ public class ContentServiceInternalImplTest {
 			secUtilsMock.when(SecurityUtils::getCurrentUser).thenReturn(mock(AuthenticatedUser.class));
 
 			studioUtilsMock.when(() -> createTempFile(anyString(), any(Document.class))).thenReturn(mock(Path.class));
-
+			studioUtilsMock.when(() -> isDescriptor(anyString())).thenCallRealMethod();
+			studioUtilsMock.when(() -> underDescriptorRoot(anyString())).thenCallRealMethod();
 			runnable.run();
 		}
 	}


### PR DESCRIPTION
Move and update API
Policy validation on write operations
https://github.com/craftercms/craftercms/issues/8086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to move content and update it in a single operation.
  * Enabled specifying new content during move operations via request body.
  * Introduced support for content update lifecycle during move actions.

* **Bug Fixes**
  * Improved validation annotations for content move and write operations.

* **Tests**
  * Added tests to verify entitlement validation during content write and delete operations.

* **Documentation**
  * Updated API documentation to include the new move-and-update endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->