### PR TITLE
Call JGit FileStoreAttributes.setBackground(true)

### DIFF
--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -43,6 +43,19 @@
 		<property name="helper" ref="studio.gitRepositoryHelper"/>
 	</bean>
 
+	<!-- This makes FileStoreAttributes.getFileStoreAttributes() to return right away and continue the
+	calculation in the background. This is a fix attempt to an issue with JGit 7.3.x + some Docker/File system combination that
+	 causes the call to hang -->
+	<bean id="jgitSetFileStoreAttributesBackground" class="org.springframework.beans.factory.config.MethodInvokingBean" lazy-init="false">
+		<property name="targetClass" value="org.eclipse.jgit.util.FS$FileStoreAttributes"/>
+		<property name="targetMethod" value="setBackground"/>
+		<property name="arguments">
+			<array>
+				<value type="boolean">true</value>
+			</array>
+		</property>
+	</bean>
+
 	<bean id="globalRepoBootstrap" class="org.craftercms.studio.impl.v2.repository.GlobalRepoBootstrap">
 		<constructor-arg name="helper" ref="studio.gitRepositoryHelper"/>
 		<constructor-arg name="studioConfiguration" ref="studioConfiguration"/>


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1150
Call JGit FileStoreAttributes.setBackground(true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application stability when interacting with file systems in certain Docker environments, preventing potential hangs during file attribute checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->