### PR TITLE
Fix typo in site-config.xml

### DIFF
--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/site-config.xml
@@ -68,7 +68,7 @@
 	names that require CDATA escaping.
 	-->
 	<cdata-escaped-field-patterns>
-		<pattern>(_html|_t|_s|_smv|mvs)$</pattern>
+		<pattern>(_html|_t|_s|_smv|_mvs)$</pattern>
 		<pattern>internal-name</pattern>
 	</cdata-escaped-field-patterns>
 

--- a/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/site-config.xml
@@ -68,7 +68,7 @@
 	names that require CDATA escaping.
 	-->
 	<cdata-escaped-field-patterns>
-		<pattern>(_html|_t|_s|_smv|mvs)$</pattern>
+		<pattern>(_html|_t|_s|_smv|_mvs)$</pattern>
 		<pattern>internal-name</pattern>
 	</cdata-escaped-field-patterns>
 

--- a/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/site-config.xml
@@ -68,7 +68,7 @@
 	names that require CDATA escaping.
 	-->
 	<cdata-escaped-field-patterns>
-		<pattern>(_html|_t|_s|_smv|mvs)$</pattern>
+		<pattern>(_html|_t|_s|_smv|_mvs)$</pattern>
 		<pattern>internal-name</pattern>
 	</cdata-escaped-field-patterns>
 

--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/site-config.xml
@@ -68,7 +68,7 @@
 	names that require CDATA escaping.
 	-->
 	<cdata-escaped-field-patterns>
-		<pattern>(_html|_t|_s|_smv|mvs)$</pattern>
+		<pattern>(_html|_t|_s|_smv|_mvs)$</pattern>
 		<pattern>internal-name</pattern>
 	</cdata-escaped-field-patterns>
 

--- a/src/main/webapp/repo-bootstrap/global/configuration/samples/sample-site-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/configuration/samples/sample-site-config.xml
@@ -62,7 +62,7 @@
 	names that require CDATA escaping.
 	-->
 	<cdata-escaped-field-patterns>
-		<pattern>(_html|_t|_s|_smv|mvs)$</pattern>
+		<pattern>(_html|_t|_s|_smv|_mvs)$</pattern>
 		<pattern>internal-name</pattern>
 	</cdata-escaped-field-patterns>
 


### PR DESCRIPTION
Fix typo in site-config.xml
https://github.com/craftercms/craftercms/issues/8314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a pattern in configuration files to consistently match field names ending with "_mvs", ensuring accurate field handling across multiple site configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->