### PR TITLE
Disk monitor email notifications disabled by default

### DIFF
--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -111,7 +111,7 @@ studio.monitoring.disk.notifications.encoding: UTF-8
 studio.monitoring.disk.notifications.dateTimePattern: MM/dd/yyyy hh:mm:ss.SSS a z
 
 # Email configs
-studio.monitoring.disk.notifications.email.enabled: true
+studio.monitoring.disk.notifications.email.enabled: false
 studio.monitoring.disk.notifications.email.subject: Disk space warning
 studio.monitoring.disk.notifications.email.to: admin@example.com
 studio.monitoring.disk.notifications.email.template: notification/templates/email/disk-monitor-alarm.ftl


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8272
Disk monitor email notifications disabled by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled email notifications for disk space alerts in the monitoring configuration. Users will no longer receive email messages when disk space thresholds are reached. This change does not affect core application functionality or other alert mechanisms already in place. Teams relying on email for operational awareness should use alternative notification channels or adjust settings to re-enable emails if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->