### PR TITLE
Interpret '/' as the root of the git repository

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
@@ -376,7 +376,7 @@ public class GitRepositoryHelper implements DisposableBean {
 	}
 
 	public String getGitPath(String path) {
-		if (StringUtils.isEmpty(path) || Strings.CI.equals(path, "/")) {
+		if (isEmpty(path) || Strings.CI.equals(path, "/")) {
 			path = ".";
 		} else {
 			path = FilenameUtils.normalize(path, true);

--- a/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
+++ b/src/main/java/org/craftercms/studio/api/v2/utils/GitRepositoryHelper.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.craftercms.commons.crypto.CryptoException;
 import org.craftercms.commons.crypto.TextEncryptor;
@@ -375,7 +376,7 @@ public class GitRepositoryHelper implements DisposableBean {
 	}
 
 	public String getGitPath(String path) {
-		if (StringUtils.isEmpty(path)) {
+		if (StringUtils.isEmpty(path) || Strings.CI.equals(path, "/")) {
 			path = ".";
 		} else {
 			path = FilenameUtils.normalize(path, true);


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8267
Interpret '/' as the root of the git repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of root repository paths by treating "/" as an empty path and resolving it to the repository root.
  * Normalized paths consistently (removing leading separators and converting to Unix-style separators) to reduce cross-platform repository errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->