### PR TITLE
Prevent soft dependencies calculation from returning paths in the main package

### DIFF
--- a/src/main/resources/org/craftercms/studio/api/v2/dal/DependencyDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/DependencyDAO.xml
@@ -62,12 +62,18 @@
 	</select>
 
 	<select id="getPublishingSoftDependenciesForList" resultMap="org.craftercms.studio.api.v2.dal.ItemDAO.LightItemMap">
-		SELECT d.target_path AS path, i.label AS meta_label, i.mime_type AS meta_mime_type, i.system_type AS meta_system_type
+		SELECT DISTINCT d.target_path AS path, i.label AS meta_label, i.mime_type AS meta_mime_type, i.system_type AS meta_system_type
 		FROM dependency d
 		INNER JOIN site s ON s.site_id = d.site
 		INNER JOIN item i ON i.path = d.target_path
 		INNER JOIN item_target it ON it.item_id = i.id AND it.target = #{target}
 		WHERE d.source_path IN
+		<foreach item="path" index="index" collection="paths"
+			 open="(" separator="," close=")">
+			#{path}
+		</foreach>
+		<!-- Prevent source paths from being returned -->
+		AND d.target_path NOT IN
 		<foreach item="path" index="index" collection="paths"
 			 open="(" separator="," close=")">
 			#{path}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8282
Prevent soft dependencies calculation from returning paths in the main package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing dependency lists now display unique items, removing duplicate entries.
  * Selected source items are no longer returned as dependencies, preventing self-references.
  * Improves accuracy and clarity of dependencies shown during publish operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->