### PR TITLE
Publisher-related UM scripts

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/constant/DmConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v1/constant/DmConstants.java
@@ -56,6 +56,7 @@ public class DmConstants {
 	public final static String KEY_SYSTEM_ASSET = "systemAsset";
 	public final static String KEY_SKIP_AUDIT_LOG_INSERT = "skipAuditLogInsert";
 	public static final String KEY_LIFECYCLE_CONTENT = "lifecycleContent";
+	public static final String KEY_LOGGER = "logger";
 
 	/**
 	 * rename keys

--- a/src/main/java/org/craftercms/studio/impl/v2/content/ContentLifecycleImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/content/ContentLifecycleImpl.java
@@ -57,6 +57,8 @@ import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurr
 public class ContentLifecycleImpl implements ContentLifecycle, ApplicationContextAware {
 	private static final Logger logger = LoggerFactory.getLogger(ContentLifecycleImpl.class);
 
+	private static final String SCRIPT_LOGGER_NAME_FORMAT = "Lifecycle-%s-%s";
+
 	protected final StudioConfiguration studioConfiguration;
 	protected final ScriptExecutor scriptExecutor;
 	protected ApplicationContext applicationContext;
@@ -140,6 +142,8 @@ public class ContentLifecycleImpl implements ContentLifecycle, ApplicationContex
 		model.put(KEY_SOURCE_PATH, lifecycleContent.getSourcePath());
 
 		model.put(KEY_LIFECYCLE_CONTENT, lifecycleContent);
+
+		model.put(KEY_LOGGER, LoggerFactory.getLogger(format(SCRIPT_LOGGER_NAME_FORMAT, siteId, lifecycleContent.getContentType())));
 
 		if (shouldIncludeApplicationContext()) {
 			model.put(KEY_APPLICATION_CONTEXT, applicationContext);

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
@@ -49,10 +49,7 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 	protected static final String CONFIG_KEY_STORED_PROCEDURE_NAME = "spName";
 
 	protected static final String QUERY_CALL_STORED_PROCEDURE =
-			"call @spName('@site', '@target', '@publishedLastCommit')";
-	protected static final String SP_PARAM_SITE = "@site";
-	protected static final String SP_PARAM_TARGET = "@target";
-	protected static final String SP_PARAM_LAST_COMMIT = "@publishedLastCommit";
+			"call @spName(?, ?, ?)";
 	protected static final String STORED_PROCEDURE_NAME = "@spName";
 
 	protected final SitesService sitesService;
@@ -125,16 +122,17 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 			throw new UpgradeException(format("The target '%s' does not exist in the published repository for site '%s'", target, site));
 		}
 		String lastCommit = lastCommitObjectId.getName();
-		logger.debug("Execute the stored procedure '{}' in site '{}' target '{}' last comit '{}", spName, site, target, lastCommit);
-		try (Connection connection = context.getConnection()) {
-			CallableStatement callableStatement = connection.prepareCall(QUERY_CALL_STORED_PROCEDURE
-					.replace(STORED_PROCEDURE_NAME, spName)
-					.replace(SP_PARAM_SITE, String.valueOf(siteId))
-					.replace(SP_PARAM_TARGET, target)
-					.replace(SP_PARAM_LAST_COMMIT, lastCommit));
-			callableStatement.execute();
+		logger.debug("Execute the stored procedure '{}' in site '{}' target '{}' last commit '{}", spName, site, target, lastCommit);
+		final String call = QUERY_CALL_STORED_PROCEDURE.replace(STORED_PROCEDURE_NAME, spName);
+		try (Connection connection = context.getConnection();
+			 CallableStatement stmt = connection.prepareCall(call)) {
+			stmt.setLong(1, siteId);
+			stmt.setString(2, target);
+			stmt.setString(3, lastCommit);
+			stmt.execute();
 		} catch (SQLException e) {
-			logger.error("Failed to populate item_target table for site '{}'", site, e);
+			logger.error("Failed to populate item_target table for site '{}' target '{}'", site, target, e);
+			throw new UpgradeException(format("Failed to populate item_target table for site '%s' target '%s'", site, target), e);
 		}
 	}
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.studio.impl.v2.upgrade.operations.db;
+
+import org.apache.commons.configuration2.HierarchicalConfiguration;
+import org.craftercms.commons.entitlements.validator.DbIntegrityValidator;
+import org.craftercms.commons.upgrade.exception.UpgradeException;
+import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
+import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
+import org.craftercms.studio.api.v2.repository.GitContentRepository;
+import org.craftercms.studio.api.v2.service.site.SitesService;
+import org.craftercms.studio.api.v2.utils.StudioConfiguration;
+import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.ConstructorProperties;
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.craftercms.studio.api.v2.utils.StudioConfiguration.DB_SCHEMA;
+
+public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOperation {
+	protected static final Logger logger = LoggerFactory.getLogger(PopulateItemTargetTableUpgradeOperation.class);
+
+	protected static final String CONFIG_KEY_STORED_PROCEDURE_NAME = "spName";
+
+	protected static final String QUERY_GET_ALL_SITES =
+			"SELECT id, site_id, published_repo_created FROM " + CRAFTER_SCHEMA_NAME + ".site WHERE system = 0 AND deleted = 0";
+	protected static final String QUERY_CALL_STORED_PROCEDURE =
+			"call @spName('@site', '@target', '@publishedLastCommit')";
+	protected static final String SP_PARAM_SITE = "@site";
+	protected static final String SP_PARAM_TARGET = "@target";
+	protected static final String SP_PARAM_LAST_COMMIT = "@publishedLastCommit";
+	protected static final String STORED_PROCEDURE_NAME = "@spName";
+
+	protected final SitesService sitesService;
+	protected final ServicesConfig servicesConfig;
+
+	protected String spName;
+	protected String crafterSchemaName;
+
+	@ConstructorProperties({"studioConfiguration", "scriptFolder", "integrityValidator", "siteService", "servicesConfig"})
+	public PopulateItemTargetTableUpgradeOperation(StudioConfiguration studioConfiguration, String scriptFolder,
+												   DbIntegrityValidator integrityValidator, SitesService sitesService,
+												   ServicesConfig servicesConfig) {
+		super(studioConfiguration, scriptFolder, integrityValidator);
+		this.sitesService = sitesService;
+		this.servicesConfig = servicesConfig;
+	}
+
+	@Override
+	public void doInit(HierarchicalConfiguration config) {
+		super.doInit(config);
+		spName = config.getString(CONFIG_KEY_STORED_PROCEDURE_NAME);
+		crafterSchemaName = studioConfiguration.getProperty(DB_SCHEMA);
+	}
+
+	@Override
+	public void doExecute(final StudioUpgradeContext context) throws UpgradeException {
+		// create stored procedure from script (if needed)
+		if (isNotEmpty(fileName)) {
+			super.doExecute(context);
+		}
+		// get all sites from DB
+		Map<Long, String> sites = new HashMap<>();
+		try (Connection connection = context.getConnection()) {
+			try (Statement statement = connection.createStatement();
+				 ResultSet rs = statement.executeQuery(
+						 QUERY_GET_ALL_SITES.replace(CRAFTER_SCHEMA_NAME, crafterSchemaName))) {
+				while (rs.next()) {
+					if (rs.getBoolean(3)) {
+						sites.put(rs.getLong(1), rs.getString(2));
+					}
+				}
+			} catch (SQLException e) {
+				logger.error("Failed to get all sites from the database", e);
+				throw new UpgradeException("Failed to get all sites from the database", e);
+			}
+		} catch (SQLException e) {
+			logger.error("Failed to get a database connection", e);
+			throw new UpgradeException("Failed to get a database connection", e);
+		}
+
+		// loop over all sites
+		for (Map.Entry<Long, String> site : sites.entrySet()) {
+			try {
+				populateItemTarget(context, site.getKey(), site.getValue());
+			} catch (SiteNotFoundException e) {
+				throw new UpgradeException(format("Failed to populate item_target table for site '%s'", site.getValue()), e);
+			}
+		}
+	}
+
+	/**
+	 * Calls the 'populate item target table' stored procedure. It takes the name from
+	 * the property 'spName'.
+	 * The SP is meant to read the item table and populate the item_target table for the active publishing targets
+	 * for the site
+	 *
+	 * @param context the upgrade context
+	 * @param site    the site id
+	 * @param siteId  the numeric site id
+	 */
+	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site) throws SiteNotFoundException {
+		String liveTarget = servicesConfig.getLiveEnvironment(site);
+		String lastCommit = ""; // TODO: Get last commit
+		populateItemTarget(context, siteId, site, liveTarget, lastCommit);
+		if (servicesConfig.isStagingEnvironmentEnabled(site)) {
+			String stagingLastCommit = "";
+			String stagingTarget = servicesConfig.getStagingEnvironment(site);
+			populateItemTarget(context, siteId, site, stagingTarget, stagingLastCommit);
+		}
+
+	}
+
+	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site, String target, String lastCommit) {
+		logger.debug("Execute the stored procedure '{}' in site '{}' target '{}'", spName, site, target);
+		try (Connection connection = context.getConnection()) {
+			CallableStatement callableStatement = connection.prepareCall(QUERY_CALL_STORED_PROCEDURE
+					.replace(STORED_PROCEDURE_NAME, spName)
+					.replace(SP_PARAM_SITE, String.valueOf(siteId))
+					.replace(SP_PARAM_TARGET, target)
+					.replace(SP_PARAM_LAST_COMMIT, lastCommit));
+			callableStatement.execute();
+		} catch (SQLException e) {
+			logger.error("Failed to populate item_target table for site '{}'", site, e);
+		}
+	}
+}

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
@@ -26,6 +26,7 @@ import org.craftercms.studio.api.v2.service.site.SitesService;
 import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,20 +109,23 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 	 * @param site    the site id
 	 * @param siteId  the numeric site id
 	 */
-	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site) throws SiteNotFoundException, IOException {
+	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site) throws SiteNotFoundException, IOException, UpgradeException {
 		String liveTarget = servicesConfig.getLiveEnvironment(site);
 		Repository repository = gitRepositoryHelper.getRepository(site, PUBLISHED);
-		String lastCommit = repository.resolve(liveTarget).getName();
-		populateItemTarget(context, siteId, site, liveTarget, lastCommit);
+		populateItemTarget(context, siteId, site, liveTarget, repository);
 		if (servicesConfig.isStagingEnvironmentEnabled(site)) {
 			String stagingTarget = servicesConfig.getStagingEnvironment(site);
-			String stagingLastCommit = repository.resolve(stagingTarget).getName();
-			populateItemTarget(context, siteId, site, stagingTarget, stagingLastCommit);
+			populateItemTarget(context, siteId, site, stagingTarget, repository);
 		}
 	}
 
-	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site, String target, String lastCommit) {
-		logger.debug("Execute the stored procedure '{}' in site '{}' target '{}'", spName, site, target);
+	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site, String target, Repository repository) throws IOException, UpgradeException {
+		ObjectId lastCommitObjectId = repository.resolve(target);
+		if (lastCommitObjectId == null) {
+			throw new UpgradeException(format("The target '%s' does not exist in the published repository for site '%s'", target, site));
+		}
+		String lastCommit = lastCommitObjectId.getName();
+		logger.debug("Execute the stored procedure '{}' in site '{}' target '{}' last comit '{}", spName, site, target, lastCommit);
 		try (Connection connection = context.getConnection()) {
 			CallableStatement callableStatement = connection.prepareCall(QUERY_CALL_STORED_PROCEDURE
 					.replace(STORED_PROCEDURE_NAME, spName)

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/db/PopulateItemTargetTableUpgradeOperation.java
@@ -21,20 +21,25 @@ import org.craftercms.commons.entitlements.validator.DbIntegrityValidator;
 import org.craftercms.commons.upgrade.exception.UpgradeException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
-import org.craftercms.studio.api.v2.repository.GitContentRepository;
+import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.service.site.SitesService;
+import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
+import org.eclipse.jgit.lib.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.beans.ConstructorProperties;
-import java.sql.*;
-import java.util.HashMap;
-import java.util.Map;
+import java.io.IOException;
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.craftercms.studio.api.v1.constant.GitRepositories.PUBLISHED;
 import static org.craftercms.studio.api.v2.utils.StudioConfiguration.DB_SCHEMA;
 
 public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOperation {
@@ -42,8 +47,6 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 
 	protected static final String CONFIG_KEY_STORED_PROCEDURE_NAME = "spName";
 
-	protected static final String QUERY_GET_ALL_SITES =
-			"SELECT id, site_id, published_repo_created FROM " + CRAFTER_SCHEMA_NAME + ".site WHERE system = 0 AND deleted = 0";
 	protected static final String QUERY_CALL_STORED_PROCEDURE =
 			"call @spName('@site', '@target', '@publishedLastCommit')";
 	protected static final String SP_PARAM_SITE = "@site";
@@ -53,17 +56,20 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 
 	protected final SitesService sitesService;
 	protected final ServicesConfig servicesConfig;
+	protected final GitRepositoryHelper gitRepositoryHelper;
 
 	protected String spName;
 	protected String crafterSchemaName;
 
-	@ConstructorProperties({"studioConfiguration", "scriptFolder", "integrityValidator", "siteService", "servicesConfig"})
+	@ConstructorProperties({"studioConfiguration", "scriptFolder", "integrityValidator",
+			"siteService", "servicesConfig", "gitRepositoryHelper"})
 	public PopulateItemTargetTableUpgradeOperation(StudioConfiguration studioConfiguration, String scriptFolder,
 												   DbIntegrityValidator integrityValidator, SitesService sitesService,
-												   ServicesConfig servicesConfig) {
+												   ServicesConfig servicesConfig, GitRepositoryHelper gitRepositoryHelper) {
 		super(studioConfiguration, scriptFolder, integrityValidator);
 		this.sitesService = sitesService;
 		this.servicesConfig = servicesConfig;
+		this.gitRepositoryHelper = gitRepositoryHelper;
 	}
 
 	@Override
@@ -79,32 +85,15 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 		if (isNotEmpty(fileName)) {
 			super.doExecute(context);
 		}
-		// get all sites from DB
-		Map<Long, String> sites = new HashMap<>();
-		try (Connection connection = context.getConnection()) {
-			try (Statement statement = connection.createStatement();
-				 ResultSet rs = statement.executeQuery(
-						 QUERY_GET_ALL_SITES.replace(CRAFTER_SCHEMA_NAME, crafterSchemaName))) {
-				while (rs.next()) {
-					if (rs.getBoolean(3)) {
-						sites.put(rs.getLong(1), rs.getString(2));
-					}
-				}
-			} catch (SQLException e) {
-				logger.error("Failed to get all sites from the database", e);
-				throw new UpgradeException("Failed to get all sites from the database", e);
-			}
-		} catch (SQLException e) {
-			logger.error("Failed to get a database connection", e);
-			throw new UpgradeException("Failed to get a database connection", e);
-		}
 
-		// loop over all sites
-		for (Map.Entry<Long, String> site : sites.entrySet()) {
-			try {
-				populateItemTarget(context, site.getKey(), site.getValue());
-			} catch (SiteNotFoundException e) {
-				throw new UpgradeException(format("Failed to populate item_target table for site '%s'", site.getValue()), e);
+		List<Site> allSites = sitesService.getAllSites();
+		for (Site site : allSites) {
+			if (site.isSitePublishedRepoCreated()) {
+				try {
+					populateItemTarget(context, site.getId(), site.getSiteId());
+				} catch (SiteNotFoundException | IOException e) {
+					throw new UpgradeException(format("Failed to populate item_target table for site '%s'", site.getSiteId()), e);
+				}
 			}
 		}
 	}
@@ -119,16 +108,16 @@ public class PopulateItemTargetTableUpgradeOperation extends DbScriptUpgradeOper
 	 * @param site    the site id
 	 * @param siteId  the numeric site id
 	 */
-	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site) throws SiteNotFoundException {
+	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site) throws SiteNotFoundException, IOException {
 		String liveTarget = servicesConfig.getLiveEnvironment(site);
-		String lastCommit = ""; // TODO: Get last commit
+		Repository repository = gitRepositoryHelper.getRepository(site, PUBLISHED);
+		String lastCommit = repository.resolve(liveTarget).getName();
 		populateItemTarget(context, siteId, site, liveTarget, lastCommit);
 		if (servicesConfig.isStagingEnvironmentEnabled(site)) {
-			String stagingLastCommit = "";
 			String stagingTarget = servicesConfig.getStagingEnvironment(site);
+			String stagingLastCommit = repository.resolve(stagingTarget).getName();
 			populateItemTarget(context, siteId, site, stagingTarget, stagingLastCommit);
 		}
-
 	}
 
 	private void populateItemTarget(final StudioUpgradeContext context, long siteId, String site, String target, String lastCommit) {

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
@@ -21,6 +21,7 @@ import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ import static org.apache.logging.log4j.util.Strings.EMPTY;
  *   error message for admins to review and manually upgrade them</li>
  * </ul>
  */
-public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgradeOperation {
+public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgradeOperation implements InitializingBean {
 
 	private static final Logger logger = LoggerFactory.getLogger(ContentTypeControllerUpgradeOperation.class);
 
@@ -47,8 +48,16 @@ public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgrad
 	private static final String TRAILING_SEMICOLON_PATTERN = "(?m)^(.*);\\s*$";
 	private static final String TRAILING_SEMICOLON_REPLACEMENT = "$1";
 
+	protected String defaultScript;
+
 	public ContentTypeControllerUpgradeOperation(StudioConfiguration studioConfiguration) {
 		super(studioConfiguration);
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		ClassPathResource defaultScriptResource = new ClassPathResource(DEFAULT_CONTROLLER_PATH);
+		defaultScript = Files.readString(Path.of(defaultScriptResource.getURI()));
 	}
 
 	@Override
@@ -90,12 +99,12 @@ public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgrad
 	 */
 	private boolean isDefaultControllerScript(String content) throws IOException {
 		String noCommentsScript = content
+				.replaceAll("\r\n", "\n")
 				.replaceAll(MULTILINE_COMMENT_PATTERN, EMPTY)
 				.replaceAll(EMPTY_LINE_PATTERN, EMPTY)
 				.replaceAll(TRAILING_SEMICOLON_PATTERN, TRAILING_SEMICOLON_REPLACEMENT);
 
-		ClassPathResource defaultScriptResource = new ClassPathResource(DEFAULT_CONTROLLER_PATH);
-		String defaultScript = Files.readString(Path.of(defaultScriptResource.getURI()));
+
 		return noCommentsScript.trim().equals(defaultScript.trim());
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
@@ -44,6 +44,8 @@ public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgrad
 	private static final String MULTILINE_COMMENT_PATTERN = "(?s)/\\*.*?\\*/";
 	private static final String EMPTY_LINE_PATTERN = "(?m)^\\s*\\n";
 	private static final String DEFAULT_CONTROLLER_PATH = "crafter/studio/upgrade/5.0.x/content-type/controller.groovy";
+	private static final String TRAILING_SEMICOLON_PATTERN = "(?m)^(.*);\\s*$";
+	private static final String TRAILING_SEMICOLON_REPLACEMENT = "$1";
 
 	public ContentTypeControllerUpgradeOperation(StudioConfiguration studioConfiguration) {
 		super(studioConfiguration);
@@ -89,7 +91,8 @@ public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgrad
 	private boolean isDefaultControllerScript(String content) throws IOException {
 		String noCommentsScript = content
 				.replaceAll(MULTILINE_COMMENT_PATTERN, EMPTY)
-				.replaceAll(EMPTY_LINE_PATTERN, EMPTY);
+				.replaceAll(EMPTY_LINE_PATTERN, EMPTY)
+				.replaceAll(TRAILING_SEMICOLON_PATTERN, TRAILING_SEMICOLON_REPLACEMENT);
 
 		ClassPathResource defaultScriptResource = new ClassPathResource(DEFAULT_CONTROLLER_PATH);
 		String defaultScript = Files.readString(Path.of(defaultScriptResource.getURI()));

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.studio.impl.v2.upgrade.operations.site;
+
+import org.craftercms.commons.upgrade.exception.UpgradeException;
+import org.craftercms.studio.api.v2.utils.StudioConfiguration;
+import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.apache.logging.log4j.util.Strings.EMPTY;
+
+/**
+ * Upgrade operation that review content type controller files:
+ * <ul>
+ *   <li>Check if they are equal to the default ones, if so, delete them</li>
+ *   <li>If they are different, comment out the whole file and add a log
+ *   error message for admins to review and manually upgrade them</li>
+ * </ul>
+ */
+public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgradeOperation {
+
+	private static final Logger logger = LoggerFactory.getLogger(ContentTypeControllerUpgradeOperation.class);
+
+	private static final String MULTILINE_COMMENT_PATTERN = "(?s)/\\*.*?\\*/";
+	private static final String EMPTY_LINE_PATTERN = "(?m)^\\s*\\n";
+	private static final String DEFAULT_CONTROLLER_PATH = "crafter/studio/upgrade/5.0.x/content-type/controller.groovy";
+
+	public ContentTypeControllerUpgradeOperation(StudioConfiguration studioConfiguration) {
+		super(studioConfiguration);
+	}
+
+	@Override
+	protected boolean shouldBeUpdated(StudioUpgradeContext context, Path file) {
+		return true;
+	}
+
+	@Override
+	protected void updateFile(StudioUpgradeContext context, Path path) throws UpgradeException {
+		try {
+			String fileContent = Files.readString(path);
+			if (isDefaultControllerScript(fileContent)) {
+				Files.delete(path);
+				return;
+			}
+			StringBuilder sb = new StringBuilder();
+			sb.append("""
+					/*
+					  WARNING: This controller script was not updated automatically.
+					  Please review and update it manually to ensure compatibility with the new version of Crafter Studio.
+					  Original content commented out below
+					*/
+					""");
+			commentOutScript(sb, fileContent);
+			sb.append("logger.error('This controller is disabled. Please review and upgrade to use the 5.0 content lifecycle API')\n");
+			Files.writeString(path, sb.toString());
+			logger.warn("Custom controller script found at {}. Please review and update it manually to ensure compatibility with the new version of Crafter Studio.", path);
+		} catch (IOException e) {
+			throw new UpgradeException("Error reading file " + path, e);
+		}
+	}
+
+	/**
+	 * Try to determine if the content is equal to the default controller script
+	 * It removes comments and empty lines before comparing the text
+	 *
+	 * @param content the content of the controller script
+	 * @return true if the content is equal to the default controller script, false otherwise
+	 */
+	private boolean isDefaultControllerScript(String content) throws IOException {
+		String noCommentsScript = content
+				.replaceAll(MULTILINE_COMMENT_PATTERN, EMPTY)
+				.replaceAll(EMPTY_LINE_PATTERN, EMPTY);
+
+		ClassPathResource defaultScriptResource = new ClassPathResource(DEFAULT_CONTROLLER_PATH);
+		String defaultScript = Files.readString(Path.of(defaultScriptResource.getURI()));
+		return noCommentsScript.trim().equals(defaultScript.trim());
+	}
+
+	/**
+	 * Comments out the whole content by adding '//' at the beginning of each line
+	 *
+	 * @param sb      the StringBuilder to append the commented content to
+	 * @param content the content to be commented out
+	 */
+	private void commentOutScript(StringBuilder sb, String content) {
+		String[] lines = content.split("\n");
+		for (String line : lines) {
+			sb.append("//").append(line).append("\n");
+		}
+	}
+}

--- a/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperation.java
@@ -97,7 +97,7 @@ public class ContentTypeControllerUpgradeOperation extends AbstractContentUpgrad
 	 * @param content the content of the controller script
 	 * @return true if the content is equal to the default controller script, false otherwise
 	 */
-	private boolean isDefaultControllerScript(String content) throws IOException {
+	private boolean isDefaultControllerScript(String content) {
 		String noCommentsScript = content
 				.replaceAll("\r\n", "\n")
 				.replaceAll(MULTILINE_COMMENT_PATTERN, EMPTY)

--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -628,7 +628,7 @@ CREATE TABLE IF NOT EXISTS `publish_package`
 	`reviewed_on`	                TIMESTAMP,
 	`published_on`	                TIMESTAMP,
 	`package_type`	                ENUM ('INITIAL_PUBLISH', 'PUBLISH_ALL', 'ITEM_LIST')    NOT NULL,
-	`commit_id`	                    CHAR(40)	    NOT NULL,
+	`commit_id`	                    CHAR(40),
 	`published_staging_commit_id`	CHAR(40),
 	`published_live_commit_id`	    CHAR(40),
 	PRIMARY KEY (`id`),
@@ -685,7 +685,7 @@ CREATE TABLE IF NOT EXISTS `item_target`
 	`item_id`       	    BIGINT	        NOT NULL,
 	`target`	            VARCHAR(20)	    NOT NULL,
 	`previous_path`         VARCHAR(2048)   NULL,
-	`last_published_on`     TIMESTAMP       NOT NULL,
+	`last_published_on`     TIMESTAMP       NULL,
 	`published_commit_id`   VARCHAR(40)     NOT NULL,
 	PRIMARY KEY(`item_id`, `target`),
 	FOREIGN KEY `item_target_item_id`(`item_id`) REFERENCES `item` (`id`) ON DELETE CASCADE

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
@@ -147,7 +147,7 @@ END ;
 
 /***************** TEMPORARY PROCEDURE UPDATES *****************/
 CREATE PROCEDURE populateItemTarget(
-	IN siteId INT,
+	IN siteId BIGINT,
 	IN publishTarget VARCHAR(20),
 	IN publishedLastCommit VARCHAR(40))
 BEGIN

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//********************** PROCEDURE UPDATES START **********************//
+
+// Updated to remote reference to publish_package table
+DROP PROCEDURE IF EXISTS deleteSiteRelatedItems ;
+
+CREATE PROCEDURE deleteSiteRelatedItems(
+	IN siteId VARCHAR(50))
+BEGIN
+	DECLARE id BIGINT(20);
+
+	IF EXISTS (SELECT (1) FROM site WHERE site_id = siteId AND deleted = 0)
+	THEN
+		SELECT s.id into id
+		FROM site s
+		WHERE site_id = siteId AND deleted = 0;
+
+		-- Item will cascade delete workflow
+		DELETE FROM item WHERE site_id = id;
+
+		-- user_properties
+		DELETE FROM user_properties WHERE site_id = id;
+
+		-- dependencies
+		DELETE FROM dependency WHERE site = siteId;
+
+		-- sequences
+		DELETE FROM navigation_order_sequence WHERE site = siteId;
+
+		-- remote repositories
+		DELETE FROM remote_repository WHERE site_id = siteId;
+
+		-- audit log
+		DELETE FROM audit WHERE site_id = id;
+
+		-- publish queue
+		DELETE FROM publish_package WHERE site_id = id;
+
+		-- processed_commits
+		DELETE FROM processed_commits WHERE site_id = id;
+	END IF;
+END ;
+
+//*********************** PROCEDURE UPDATES END ***********************//
+
+//************************* NEW TABLES START *************************//
+
+/*
+	Package level data for a publish request
+*/
+CREATE TABLE IF NOT EXISTS `publish_package`
+(
+	`id`	                        BIGINT(20)      NOT NULL AUTO_INCREMENT,
+	`site_id`	                    BIGINT(20)	    NOT NULL,
+	`target`	                    VARCHAR(20)	    NOT NULL,
+	`title`                         VARCHAR(200)    NOT NULL,
+	`schedule`	                    TIMESTAMP,
+	`approval_state`	            ENUM ('SUBMITTED', 'APPROVED', 'REJECTED')	NOT NULL,
+	`package_state`	                BIGINT          NOT NULL,
+	`live_error`	                INT,
+	`staging_error`	                INT,
+	`submitter_id`	                BIGINT(20),
+	`submitter_comment`	            TEXT,
+	`submitted_on`	                TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`reviewer_id`	                BIGINT(20),
+	`reviewer_comment`          	TEXT,
+	`reviewed_on`	                TIMESTAMP,
+	`published_on`	                TIMESTAMP,
+	`package_type`	                ENUM ('INITIAL_PUBLISH', 'PUBLISH_ALL', 'ITEM_LIST')    NOT NULL,
+	`commit_id`	                    CHAR(40)	    NOT NULL,
+	`published_staging_commit_id`	CHAR(40),
+	`published_live_commit_id`	    CHAR(40),
+	PRIMARY KEY (`id`),
+	FOREIGN KEY `publish_package_site_id`(`site_id`) REFERENCES `site` (`id`) ON DELETE CASCADE,
+	FOREIGN KEY `publish_package_submitter_id`(`submitter_id`) REFERENCES `user` (`id`),
+	FOREIGN KEY `publish_package_reviewer_id`(`reviewer_id`) REFERENCES `user` (`id`),
+	INDEX `publish_package_package_state` (`package_state`)
+)
+	ENGINE = InnoDB
+	DEFAULT CHARSET = utf8
+	ROW_FORMAT = DYNAMIC ;
+
+/*
+	An item to be published as part of a package
+*/
+CREATE TABLE IF NOT EXISTS `publish_item`
+(
+	`id`                    BIGINT(20)              NOT NULL AUTO_INCREMENT,
+	`package_id`            BIGINT(20)	            NOT NULL,
+	`path`                  VARCHAR(2048)	        NOT NULL,
+	`live_previous_path`    VARCHAR(2048),
+	`staging_previous_path` VARCHAR(2048),
+	`action`	            ENUM('ADD', 'UPDATE', 'DELETE')   NOT NULL,
+	`user_requested`    	BOOLEAN	                NOT NULL,
+	`publish_state`         BIGINT      	        NOT NULL,
+	`live_error`            INT,
+	`staging_error`         INT,
+	PRIMARY KEY(`id`),
+	FOREIGN KEY `publish_item_package_id`(`package_id`) REFERENCES `publish_package` (`id`) ON DELETE CASCADE
+)
+	ENGINE = InnoDB
+	DEFAULT CHARSET = utf8
+	ROW_FORMAT = DYNAMIC ;
+
+/*
+	Allows to link a publish_item to an item if it exists (items can be deleted afterwards)
+*/
+CREATE TABLE IF NOT EXISTS `item_publish_item`
+(
+	`publish_item_id`	BIGINT  NOT NULL,
+	`item_id`	        BIGINT  NOT NULL,
+	FOREIGN KEY `item_publish_item_publish_item_id`(`publish_item_id`) REFERENCES `publish_item` (`id`) ON DELETE CASCADE,
+	FOREIGN KEY `item_publish_item_item_id`(`item_id`) REFERENCES `item` (`id`) ON DELETE CASCADE
+)
+	ENGINE = InnoDB
+	DEFAULT CHARSET = utf8
+	ROW_FORMAT = DYNAMIC ;
+
+/*
+	Keep track of old paths for published-and-then-renamed content items
+*/
+CREATE TABLE IF NOT EXISTS `item_target`
+(
+	`item_id`       	    BIGINT	        NOT NULL,
+	`target`	            VARCHAR(20)	    NOT NULL,
+	`previous_path`         VARCHAR(2048)   NULL,
+	`last_published_on`     TIMESTAMP       NOT NULL,
+	`published_commit_id`   VARCHAR(40)     NOT NULL,
+	PRIMARY KEY(`item_id`, `target`),
+	FOREIGN KEY `item_target_item_id`(`item_id`) REFERENCES `item` (`id`) ON DELETE CASCADE
+)
+	ENGINE = InnoDB
+	DEFAULT CHARSET = utf8
+	ROW_FORMAT = DYNAMIC ;
+
+//************************** NEW TABLES END **************************//

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
@@ -14,8 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/************************* NEW TABLES START *************************/
-
+/************************* NEW TABLES *************************/
 /*
 	Package level data for a publish request
 */
@@ -105,10 +104,8 @@ CREATE TABLE IF NOT EXISTS `item_target`
 	DEFAULT CHARSET = utf8
 	ROW_FORMAT = DYNAMIC ;
 
-/************************** NEW TABLES END **************************/
-
-/********************** PROCEDURE UPDATES START **********************/
-// Updated to remote reference to publish_package table
+/********************** PROCEDURE UPDATES **********************/
+/* Updated to remove reference to publish_package table */
 DROP PROCEDURE IF EXISTS deleteSiteRelatedItems ;
 
 CREATE PROCEDURE deleteSiteRelatedItems(
@@ -148,9 +145,7 @@ BEGIN
 	END IF;
 END ;
 
-/*********************** PROCEDURE UPDATES END ***********************/
-
-/***************** TEMPORARY PROCEDURE UPDATES START *****************/
+/***************** TEMPORARY PROCEDURE UPDATES *****************/
 CREATE PROCEDURE populateItemTarget(
 	IN siteId INT,
 	IN publishTarget VARCHAR(20),
@@ -162,4 +157,3 @@ BEGIN
 		FROM item i
 		WHERE i.site_id = siteId;
 END ;
-/****************** TEMPORARY PROCEDURE UPDATES END ******************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
@@ -14,50 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//********************** PROCEDURE UPDATES START **********************//
-
-// Updated to remote reference to publish_package table
-DROP PROCEDURE IF EXISTS deleteSiteRelatedItems ;
-
-CREATE PROCEDURE deleteSiteRelatedItems(
-	IN siteId VARCHAR(50))
-BEGIN
-	DECLARE id BIGINT(20);
-
-	IF EXISTS (SELECT (1) FROM site WHERE site_id = siteId AND deleted = 0)
-	THEN
-		SELECT s.id into id
-		FROM site s
-		WHERE site_id = siteId AND deleted = 0;
-
-		-- Item will cascade delete workflow
-		DELETE FROM item WHERE site_id = id;
-
-		-- user_properties
-		DELETE FROM user_properties WHERE site_id = id;
-
-		-- dependencies
-		DELETE FROM dependency WHERE site = siteId;
-
-		-- sequences
-		DELETE FROM navigation_order_sequence WHERE site = siteId;
-
-		-- remote repositories
-		DELETE FROM remote_repository WHERE site_id = siteId;
-
-		-- audit log
-		DELETE FROM audit WHERE site_id = id;
-
-		-- publish queue
-		DELETE FROM publish_package WHERE site_id = id;
-
-		-- processed_commits
-		DELETE FROM processed_commits WHERE site_id = id;
-	END IF;
-END ;
-
-//*********************** PROCEDURE UPDATES END ***********************//
-
 //************************* NEW TABLES START *************************//
 
 /*
@@ -82,9 +38,10 @@ CREATE TABLE IF NOT EXISTS `publish_package`
 	`reviewed_on`	                TIMESTAMP,
 	`published_on`	                TIMESTAMP,
 	`package_type`	                ENUM ('INITIAL_PUBLISH', 'PUBLISH_ALL', 'ITEM_LIST')    NOT NULL,
-	`commit_id`	                    CHAR(40)	    NOT NULL,
+	`commit_id`	                    CHAR(40),
 	`published_staging_commit_id`	CHAR(40),
 	`published_live_commit_id`	    CHAR(40),
+	`old_package_id`	            VARCHAR(50), -- This is a temporary column to group the publish items of a package
 	PRIMARY KEY (`id`),
 	FOREIGN KEY `publish_package_site_id`(`site_id`) REFERENCES `site` (`id`) ON DELETE CASCADE,
 	FOREIGN KEY `publish_package_submitter_id`(`submitter_id`) REFERENCES `user` (`id`),
@@ -139,8 +96,8 @@ CREATE TABLE IF NOT EXISTS `item_target`
 	`item_id`       	    BIGINT	        NOT NULL,
 	`target`	            VARCHAR(20)	    NOT NULL,
 	`previous_path`         VARCHAR(2048)   NULL,
-	`last_published_on`     TIMESTAMP       NOT NULL,
-	`published_commit_id`   VARCHAR(40)     NOT NULL,
+	`last_published_on`     TIMESTAMP       NULL,
+	`published_commit_id`   VARCHAR(40)     NULL,
 	PRIMARY KEY(`item_id`, `target`),
 	FOREIGN KEY `item_target_item_id`(`item_id`) REFERENCES `item` (`id`) ON DELETE CASCADE
 )
@@ -149,3 +106,60 @@ CREATE TABLE IF NOT EXISTS `item_target`
 	ROW_FORMAT = DYNAMIC ;
 
 //************************** NEW TABLES END **************************//
+
+//********************** PROCEDURE UPDATES START **********************//
+// Updated to remote reference to publish_package table
+DROP PROCEDURE IF EXISTS deleteSiteRelatedItems ;
+
+CREATE PROCEDURE deleteSiteRelatedItems(
+	IN siteId VARCHAR(50))
+BEGIN
+	DECLARE id BIGINT(20);
+
+	IF EXISTS (SELECT (1) FROM site WHERE site_id = siteId AND deleted = 0)
+	THEN
+		SELECT s.id into id
+		FROM site s
+		WHERE site_id = siteId AND deleted = 0;
+
+		-- Item will cascade delete workflow
+		DELETE FROM item WHERE site_id = id;
+
+		-- user_properties
+		DELETE FROM user_properties WHERE site_id = id;
+
+		-- dependencies
+		DELETE FROM dependency WHERE site = siteId;
+
+		-- sequences
+		DELETE FROM navigation_order_sequence WHERE site = siteId;
+
+		-- remote repositories
+		DELETE FROM remote_repository WHERE site_id = siteId;
+
+		-- audit log
+		DELETE FROM audit WHERE site_id = id;
+
+		-- publish queue
+		DELETE FROM publish_package WHERE site_id = id;
+
+		-- processed_commits
+		DELETE FROM processed_commits WHERE site_id = id;
+	END IF;
+END ;
+
+//*********************** PROCEDURE UPDATES END ***********************//
+
+//***************** TEMPORARY PROCEDURE UPDATES START *****************//
+CREATE PROCEDURE populateItemTarget(
+	IN siteId INT,
+	IN publishTarget VARCHAR(20),
+	IN publishedLastCommit VARCHAR(40))
+BEGIN
+	INSERT INTO item_target
+			(item_id, target, previous_path, last_published_on, published_commit_id)
+		SELECT i.id, publishTarget, i.previous_path, i.last_published_on, publishedLastCommit
+		FROM item i
+		WHERE i.site_id = siteId;
+END ;
+//****************** TEMPORARY PROCEDURE UPDATES END ******************//

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//************************* NEW TABLES START *************************//
+/************************* NEW TABLES START *************************/
 
 /*
 	Package level data for a publish request
@@ -105,9 +105,9 @@ CREATE TABLE IF NOT EXISTS `item_target`
 	DEFAULT CHARSET = utf8
 	ROW_FORMAT = DYNAMIC ;
 
-//************************** NEW TABLES END **************************//
+/************************** NEW TABLES END **************************/
 
-//********************** PROCEDURE UPDATES START **********************//
+/********************** PROCEDURE UPDATES START **********************/
 // Updated to remote reference to publish_package table
 DROP PROCEDURE IF EXISTS deleteSiteRelatedItems ;
 
@@ -148,9 +148,9 @@ BEGIN
 	END IF;
 END ;
 
-//*********************** PROCEDURE UPDATES END ***********************//
+/*********************** PROCEDURE UPDATES END ***********************/
 
-//***************** TEMPORARY PROCEDURE UPDATES START *****************//
+/***************** TEMPORARY PROCEDURE UPDATES START *****************/
 CREATE PROCEDURE populateItemTarget(
 	IN siteId INT,
 	IN publishTarget VARCHAR(20),
@@ -162,4 +162,4 @@ BEGIN
 		FROM item i
 		WHERE i.site_id = siteId;
 END ;
-//****************** TEMPORARY PROCEDURE UPDATES END ******************//
+/****************** TEMPORARY PROCEDURE UPDATES END ******************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -21,10 +21,13 @@ INSERT INTO publish_package
 
 		SELECT s.id, pr.environment, 'Migrated package', pr.scheduleddate, IF(w.state = 'OPENED', 'SUBMITTED', IF(pr.state = 'CANCELLED', 'REJECTED', 'APPROVED')) AS approval_state,
 				CASE pr.state
-					WHEN 'READY_FOR_LIVE' THEN POWER(2, 0) -- READY
-					WHEN 'PROCESSING' THEN POWER(2, 0) -- READY
-					WHEN 'COMPLETED' THEN POWER(2, 8) + IF(pr.environment = 'live', POWER(2, 2) + POWER(2, 5), POWER(2, 5)) -- COMPLETED + LIVE_SUCCESS + STAGING_SUCCESS
-					ELSE POWER(2, 9) -- Anything else (cancelled, blocked, processing) is CANCELLED
+					WHEN 'READY_FOR_LIVE' THEN 1 -- READY = 2⁰
+					WHEN 'PROCESSING' THEN 1 -- READY = 2⁰
+					-- COMPLETED = 2⁸ = 256
+					-- LIVE_SUCCESS + STAGING_SUCCESS = 2² + 2⁵ = 4 + 32 = 36
+					-- STAGING_SUCCESS = 2⁵ = 32
+					WHEN 'COMPLETED' THEN 256 + IF(pr.environment = 'live', 36, 32)
+					ELSE 512 -- Anything else (cancelled, blocked, processing) is CANCELLED = 2⁹ = 512
 				END AS package_state,
 				0 AS live_error, 0 as staging_error, IFNULL(w.submitter_id, (SELECT u.id FROM user u WHERE u.username = pr.username)) AS submitter_id,
 				pr.submissioncomment, w.submitted_on, w.reviewer_id, w.reviewer_comment, NULL,
@@ -49,8 +52,10 @@ INSERT INTO publish_item
 					ELSE 'UPDATE'
 				END AS action, true AS user_requested,
 				CASE pr.state
-					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', POWER(2, 2) + POWER(2, 4), POWER(2, 4)) -- if live, live_success+staging_success, otherwise staging_success
-					ELSE POWER(2, 0) -- PENDING, default value
+					-- LIVE_SUCCESS = 2² = 4
+					-- STAGING_SUCCESS = 2⁴ = 16
+					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', 20, 16) -- if live, LIVE_SUCCESS + STAGING_SUCCESS, otherwise STAGING_SUCCESS
+					ELSE 1 -- PENDING = 2⁰ = 1, default value
 				END AS publish_state, 0, 0
 			FROM publish_request pr ;
 
@@ -62,4 +67,4 @@ INSERT INTO item_publish_item
 				INNER JOIN publish_package pp ON pp.id = pi.package_id
 				INNER JOIN site s ON pp.site_id = s.id
 				INNER JOIN item i ON i.path = pi.path AND i.site_id = s.id
-			WHERE pi.publish_state = 1 AND pi.action <> 'DELETE' ;
+			WHERE pi.publish_state = 1 AND pi.action <> 'DELETE' ; -- We only need the item_publish_item for the PENDING items that are not deleted

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -13,12 +13,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-/*
-- populate publish_package
-- Populate publish_item
-- Populate item_publish_item for READY packages
-*/
+/************************* POPULATE  publish_package *************************/
 INSERT INTO publish_package
 			(site_id, target, title, schedule, approval_state, package_state, live_error, staging_error, submitter_id,
 			 submitter_comment, submitted_on, reviewer_id, reviewer_comment, reviewed_on, published_on, package_type, commit_id,
@@ -27,17 +22,19 @@ INSERT INTO publish_package
 		SELECT s.id, pr.environment, 'Migrated package', pr.scheduleddate, IF(w.state = 'OPENED', 'SUBMITTED', IF(pr.state = 'CANCELLED', 'REJECTED', 'APPROVED')) AS approval_state,
 				CASE pr.state
 					WHEN 'READY_FOR_LIVE' THEN POWER(2, 0) -- READY
-					WHEN 'COMPLETED' THEN POWER(2, 8) + IF(pr.environment = 'live', POWER(2, 2), POWER(2, 2) + POWER(2, 5)) -- COMPLETED + LIVE_SUCCESS + STAGING_SUCCESS
+					WHEN 'PROCESSING' THEN POWER(2, 0) -- READY
+					WHEN 'COMPLETED' THEN POWER(2, 8) + IF(pr.environment = 'live', POWER(2, 2) + POWER(2, 5), POWER(2, 5)) -- COMPLETED + LIVE_SUCCESS + STAGING_SUCCESS
 					ELSE POWER(2, 9) -- Anything else (cancelled, blocked, processing) is CANCELLED
 				END AS package_state,
-				0 AS live_error, 0 as staging_error, w.submitter_id, pr.submissioncomment, w.submitted_on, w.reviewer_id, w.reviewer_comment, NULL,
+				0 AS live_error, 0 as staging_error, IFNULL(w.submitter_id, (SELECT u.id FROM user u WHERE u.username = pr.username)) AS submitter_id,
+				pr.submissioncomment, w.submitted_on, w.reviewer_id, w.reviewer_comment, NULL,
 				pr.published_on, 'ITEM_LIST', NULL, NULL, NULL, pr.package_id
 		FROM publish_request pr
 			INNER JOIN site s ON s.site_id = pr.site
-			LEFT JOIN item i ON pr.path = i.path
-			LEFT JOIN workflow w ON w.item_id = i.id
+			LEFT JOIN workflow w ON w.publishing_package_id = pr.package_id
 		GROUP BY pr.package_id ;
 
+/************************* POPULATE  publish_item *************************/
 INSERT INTO publish_item
 			(package_id, path, live_previous_path, staging_previous_path,
 			`action`, user_requested, publish_state, live_error, staging_error)
@@ -52,11 +49,12 @@ INSERT INTO publish_item
 					ELSE 'UPDATE'
 				END AS action, true AS user_requested,
 				CASE pr.state
-					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', POWER(2, 2), POWER(2, 2) + POWER(2, 4)) -- if live, live_success, otherwise live_success+staging_success
+					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', POWER(2, 2) + POWER(2, 4), POWER(2, 4)) -- if live, live_success+staging_success, otherwise staging_success
 					ELSE POWER(2, 0) -- PENDING, default value
 				END AS publish_state, 0, 0
 			FROM publish_request pr ;
 
+/************************* POPULATE  item_publish_item *************************/
 INSERT INTO item_publish_item
 			(publish_item_id, item_id)
 			SELECT pi.id, i.id

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -19,22 +19,24 @@ INSERT INTO publish_package
 			 submitter_comment, submitted_on, reviewer_id, reviewer_comment, reviewed_on, published_on, package_type, commit_id,
 			 published_staging_commit_id, published_live_commit_id, old_package_id)
 
-		SELECT s.id, pr.environment, 'Migrated package', pr.scheduleddate, IF(w.state = 'OPENED', 'SUBMITTED', IF(pr.state = 'CANCELLED', 'REJECTED', 'APPROVED')) AS approval_state,
-				CASE pr.state
+		SELECT MIN(s.id), MIN(pr.environment), 'Migrated package', MIN(pr.scheduleddate), IF(MIN(w.state) = 'OPENED', 'SUBMITTED',
+				IF(MIN(pr.state) = 'CANCELLED', 'REJECTED', 'APPROVED')) AS approval_state,
+				CASE MIN(pr.state)
 					WHEN 'READY_FOR_LIVE' THEN 1 -- READY = 2⁰
 					WHEN 'PROCESSING' THEN 1 -- READY = 2⁰
 					-- COMPLETED = 2⁸ = 256
 					-- LIVE_SUCCESS + STAGING_SUCCESS = 2² + 2⁵ = 4 + 32 = 36
 					-- STAGING_SUCCESS = 2⁵ = 32
-					WHEN 'COMPLETED' THEN 256 + IF(pr.environment = 'live', 36, 32)
+					WHEN 'COMPLETED' THEN 256 + IF(MIN(pr.environment)= 'live', 36, 32)
 					ELSE 512 -- Anything else (cancelled, blocked, processing) is CANCELLED = 2⁹ = 512
 				END AS package_state,
-				0 AS live_error, 0 as staging_error, IFNULL(w.submitter_id, (SELECT u.id FROM user u WHERE u.username = pr.username)) AS submitter_id,
-				pr.submissioncomment, w.submitted_on, w.reviewer_id, w.reviewer_comment, NULL,
-				pr.published_on, 'ITEM_LIST', NULL, NULL, NULL, pr.package_id
+				0 AS live_error, 0 as staging_error, IFNULL(MIN(w.submitter_id), MIN(u.id)) AS submitter_id,
+				MIN(pr.submissioncomment), MIN(w.submitted_on), MIN(w.reviewer_id), MIN(w.reviewer_comment), NULL,
+				MIN(pr.published_on), 'ITEM_LIST', NULL, NULL, NULL, MIN(pr.package_id)
 		FROM publish_request pr
 			INNER JOIN site s ON s.site_id = pr.site
 			LEFT JOIN workflow w ON w.publishing_package_id = pr.package_id
+			LEFT JOIN user u ON u.username = pr.username
 		GROUP BY pr.package_id ;
 
 /************************* POPULATE  publish_item *************************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -14,6 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-ALTER TABLE `group_user` ADD COLUMN IF NOT EXISTS `externally_managed` INT NOT NULL DEFAULT 0 ;
+// TODO: implement: migrate data from old publisher tables to new ones
 
-UPDATE `_meta` SET `version` = '5.0.0.2' ;
+
+SELECT 1 ;

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -43,10 +43,7 @@ INSERT INTO publish_package
 INSERT INTO publish_item
 			(package_id, path, live_previous_path, staging_previous_path,
 			`action`, user_requested, publish_state, live_error, staging_error)
-			SELECT
-				(SELECT pp.id
-					FROM publish_package pp
-					WHERE pp.old_package_id = pr.package_id) AS package_id,
+			SELECT pp.id AS package_id,
 				pr.path, pr.oldpath, pr.oldpath,
 				CASE pr.action
 					WHEN 'NEW' THEN 'ADD'
@@ -59,7 +56,8 @@ INSERT INTO publish_item
 					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', 20, 16) -- if live, LIVE_SUCCESS + STAGING_SUCCESS, otherwise STAGING_SUCCESS
 					ELSE 1 -- PENDING = 2⁰ = 1, default value
 				END AS publish_state, 0, 0
-			FROM publish_request pr ;
+			FROM publish_request pr
+			INNER JOIN publish_package pp ON pp.old_package_id = pr.package_id ;
 
 /************************* POPULATE  item_publish_item *************************/
 INSERT INTO item_publish_item

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -39,12 +39,32 @@ INSERT INTO publish_package
 			LEFT JOIN user u ON u.username = pr.username
 		GROUP BY pr.package_id ;
 
+/*
+	'SUBMITTED' (pending approval) packages are migrated from the 'OPENED' workflow records, which don't have a package id yet
+	To create a 5.x publish_package, we group the items submitted by the same submitter_id on the submitted_on date as packages
+ */
+INSERT INTO publish_package
+			(site_id, target, title, schedule, approval_state, package_state, live_error, staging_error, submitter_id,
+			 submitter_comment, submitted_on, reviewer_id, reviewer_comment, reviewed_on, published_on, package_type, commit_id,
+			 published_staging_commit_id, published_live_commit_id, old_package_id)
+		SELECT i.site_id, w.target_environment, 'Migrated package', w.schedule, 'SUBMITTED',
+				-- READY = 2⁰ = 1
+				1 AS package_state, 0 AS live_error, 0 as staging_error, submitter_id, MIN(submitter_comment), w.submitted_on,
+				NULL, NULL, NULL, NULL, 'ITEM_LIST', s.last_commit_id, NULL, NULL, CONCAT(submitted_on, '_', submitter_id)
+		FROM workflow w
+		INNER JOIN item i ON i.id = w.item_id
+		INNER JOIN site s ON s.id = i.site_id
+		WHERE w.publishing_package_id IS NULL
+		AND w.state = 'OPENED'
+		-- Group the items submitted by the same user on the same date as packages
+		GROUP BY i.site_id, w.submitted_on, w.submitter_id ;
+
 /************************* POPULATE  publish_item *************************/
 INSERT INTO publish_item
 			(package_id, path, live_previous_path, staging_previous_path,
 			`action`, user_requested, publish_state, live_error, staging_error)
 			SELECT pp.id AS package_id,
-				pr.path, pr.oldpath, pr.oldpath,
+				pr.path, pr.oldpath AS live_previous_path, pr.oldpath AS staging_previous_path,
 				CASE pr.action
 					WHEN 'NEW' THEN 'ADD'
 					WHEN 'DELETE' THEN 'DELETE'
@@ -55,9 +75,24 @@ INSERT INTO publish_item
 					-- STAGING_SUCCESS = 2⁴ = 16
 					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', 20, 16) -- if live, LIVE_SUCCESS + STAGING_SUCCESS, otherwise STAGING_SUCCESS
 					ELSE 1 -- PENDING = 2⁰ = 1, default value
-				END AS publish_state, 0, 0
+				END AS publish_state, 0 AS live_error, 0 AS staging_error
 			FROM publish_request pr
 			INNER JOIN publish_package pp ON pp.old_package_id = pr.package_id ;
+
+INSERT INTO publish_item
+			(package_id, path, live_previous_path, staging_previous_path,
+			`action`, user_requested, publish_state, live_error, staging_error)
+			SELECT pp.id AS package_id, i.path, i.previous_path AS live_previous_path, i.previous_path AS staging_previous_path,
+						-- state = 1 means NEW
+						IF((i.state & 1 > 0), 'ADD', 'UPDATE') AS action, true AS user_requested,
+						1 AS publish_state, -- PENDING = 2⁰ = 1
+						0 AS live_error, 0 AS staging_error
+			FROM workflow w
+			INNER JOIN item i ON i.id = w.item_id
+			INNER JOIN publish_package pp ON pp.old_package_id = CONCAT(w.submitted_on, '_', w.submitter_id)
+										AND pp.site_id = i.site_id
+			WHERE w.publishing_package_id IS NULL
+			AND w.state = 'OPENED' ;
 
 /************************* POPULATE  item_publish_item *************************/
 INSERT INTO item_publish_item

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -47,10 +47,10 @@ INSERT INTO publish_package
 			(site_id, target, title, schedule, approval_state, package_state, live_error, staging_error, submitter_id,
 			 submitter_comment, submitted_on, reviewer_id, reviewer_comment, reviewed_on, published_on, package_type, commit_id,
 			 published_staging_commit_id, published_live_commit_id, old_package_id)
-		SELECT i.site_id, w.target_environment, 'Migrated package', w.schedule, 'SUBMITTED',
+		SELECT i.site_id, MIN(w.target_environment), 'Migrated package', MIN(w.schedule), 'SUBMITTED',
 				-- READY = 2⁰ = 1
 				1 AS package_state, 0 AS live_error, 0 as staging_error, submitter_id, MIN(submitter_comment), w.submitted_on,
-				NULL, NULL, NULL, NULL, 'ITEM_LIST', s.last_commit_id, NULL, NULL, CONCAT(submitted_on, '_', submitter_id)
+				NULL, NULL, NULL, NULL, 'ITEM_LIST', MIN(s.last_commit_id), NULL, NULL, CONCAT(w.submitted_on, '_', w.submitter_id)
 		FROM workflow w
 		INNER JOIN item i ON i.id = w.item_id
 		INNER JOIN site s ON s.id = i.site_id
@@ -77,7 +77,9 @@ INSERT INTO publish_item
 					ELSE 1 -- PENDING = 2⁰ = 1, default value
 				END AS publish_state, 0 AS live_error, 0 AS staging_error
 			FROM publish_request pr
-			INNER JOIN publish_package pp ON pp.old_package_id = pr.package_id ;
+			INNER JOIN site s ON s.site_id = pr.site
+			INNER JOIN publish_package pp ON pp.old_package_id = pr.package_id AND pp.site_id = s.id
+			WHERE s.deleted = 0 AND s.system = 0 ;
 
 INSERT INTO publish_item
 			(package_id, path, live_previous_path, staging_previous_path,

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
@@ -14,7 +14,54 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// TODO: implement: migrate data from old publisher tables to new ones
+/*
+- populate publish_package
+- Populate publish_item
+- Populate item_publish_item for READY packages
+*/
+INSERT INTO publish_package
+			(site_id, target, title, schedule, approval_state, package_state, live_error, staging_error, submitter_id,
+			 submitter_comment, submitted_on, reviewer_id, reviewer_comment, reviewed_on, published_on, package_type, commit_id,
+			 published_staging_commit_id, published_live_commit_id, old_package_id)
 
+		SELECT s.id, pr.environment, 'Migrated package', pr.scheduleddate, IF(w.state = 'OPENED', 'SUBMITTED', IF(pr.state = 'CANCELLED', 'REJECTED', 'APPROVED')) AS approval_state,
+				CASE pr.state
+					WHEN 'READY_FOR_LIVE' THEN POWER(2, 0) -- READY
+					WHEN 'COMPLETED' THEN POWER(2, 8) + IF(pr.environment = 'live', POWER(2, 2), POWER(2, 2) + POWER(2, 5)) -- COMPLETED + LIVE_SUCCESS + STAGING_SUCCESS
+					ELSE POWER(2, 9) -- Anything else (cancelled, blocked, processing) is CANCELLED
+				END AS package_state,
+				0 AS live_error, 0 as staging_error, w.submitter_id, pr.submissioncomment, w.submitted_on, w.reviewer_id, w.reviewer_comment, NULL,
+				pr.published_on, 'ITEM_LIST', NULL, NULL, NULL, pr.package_id
+		FROM publish_request pr
+			INNER JOIN site s ON s.site_id = pr.site
+			LEFT JOIN item i ON pr.path = i.path
+			LEFT JOIN workflow w ON w.item_id = i.id
+		GROUP BY pr.package_id ;
 
-SELECT 1 ;
+INSERT INTO publish_item
+			(package_id, path, live_previous_path, staging_previous_path,
+			`action`, user_requested, publish_state, live_error, staging_error)
+			SELECT
+				(SELECT pp.id
+					FROM publish_package pp
+					WHERE pp.old_package_id = pr.package_id) AS package_id,
+				pr.path, pr.oldpath, pr.oldpath,
+				CASE pr.action
+					WHEN 'NEW' THEN 'ADD'
+					WHEN 'DELETE' THEN 'DELETE'
+					ELSE 'UPDATE'
+				END AS action, true AS user_requested,
+				CASE pr.state
+					WHEN 'COMPLETED' THEN IF(pr.environment = 'live', POWER(2, 2), POWER(2, 2) + POWER(2, 4)) -- if live, live_success, otherwise live_success+staging_success
+					ELSE POWER(2, 0) -- PENDING, default value
+				END AS publish_state, 0, 0
+			FROM publish_request pr ;
+
+INSERT INTO item_publish_item
+			(publish_item_id, item_id)
+			SELECT pi.id, i.id
+			FROM publish_item pi
+				INNER JOIN publish_package pp ON pp.id = pi.package_id
+				INNER JOIN site s ON pp.site_id = s.id
+				INNER JOIN item i ON i.path = pi.path AND i.site_id = s.id
+			WHERE pi.publish_state = 1 AND pi.action <> 'DELETE' ;

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
@@ -14,17 +14,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/************************* DELETE TABLES START *************************/
+/************************* DELETE TABLES *************************/
 DROP TABLE IF EXISTS `publish_request` ;
 DROP TABLE IF EXISTS `workflow` ;
-/************************** DELETE TABLES END **************************/
 
-/************************* DELETE COLUMNS START *************************/
+/************************* DELETE COLUMNS *************************/
 ALTER TABLE `item` DROP COLUMN `last_published_on` ;
 ALTER TABLE `item` DROP COLUMN `previous_path` ;
 ALTER TABLE `publish_package` DROP COLUMN `old_package_id` ;
-/************************** DELETE COLUMNS END **************************/
 
-/************************* DROP PROCEDURES START *************************/
+/************************* DROP PROCEDURES *************************/
 DROP PROCEDURE IF EXISTS populateItemTarget ;
-/************************** DROP PROCEDURES END **************************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
@@ -26,5 +26,5 @@ ALTER TABLE `publish_package` DROP COLUMN `old_package_id` ;
 /************************** DELETE COLUMNS END **************************/
 
 /************************* DROP PROCEDURES START *************************/
-DROP PROCEDURE IF EXISTS populateItemTarget
+DROP PROCEDURE IF EXISTS populateItemTarget ;
 /************************** DROP PROCEDURES END **************************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
@@ -14,6 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-ALTER TABLE `group_user` ADD COLUMN IF NOT EXISTS `externally_managed` INT NOT NULL DEFAULT 0 ;
+//************************* DELETE TABLES AND COLUMNS START *************************//
 
-UPDATE `_meta` SET `version` = '5.0.0.2' ;
+DROP TABLE IF EXISTS `publish_request` ;
+DROP TABLE IF EXISTS `workflow` ;
+
+ALTER TABLE `item` DROP COLUMN `last_published_on` ;
+ALTER TABLE `item` DROP COLUMN `previous_path` ;
+
+//************************** DELETE TABLES AND COLUMNS END **************************//

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
@@ -14,17 +14,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//************************* DELETE TABLES START *************************//
+/************************* DELETE TABLES START *************************/
 DROP TABLE IF EXISTS `publish_request` ;
 DROP TABLE IF EXISTS `workflow` ;
-//************************** DELETE TABLES END **************************//
+/************************** DELETE TABLES END **************************/
 
-//************************* DELETE COLUMNS START *************************//
+/************************* DELETE COLUMNS START *************************/
 ALTER TABLE `item` DROP COLUMN `last_published_on` ;
 ALTER TABLE `item` DROP COLUMN `previous_path` ;
 ALTER TABLE `publish_package` DROP COLUMN `old_package_id` ;
-//************************** DELETE COLUMNS END **************************//
+/************************** DELETE COLUMNS END **************************/
 
-//************************* DROP PROCEDURES START *************************//
+/************************* DROP PROCEDURES START *************************/
 DROP PROCEDURE IF EXISTS populateItemTarget
-//************************** DROP PROCEDURES END **************************//
+/************************** DROP PROCEDURES END **************************/

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
@@ -14,12 +14,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//************************* DELETE TABLES AND COLUMNS START *************************//
-
+//************************* DELETE TABLES START *************************//
 DROP TABLE IF EXISTS `publish_request` ;
 DROP TABLE IF EXISTS `workflow` ;
+//************************** DELETE TABLES END **************************//
 
+//************************* DELETE COLUMNS START *************************//
 ALTER TABLE `item` DROP COLUMN `last_published_on` ;
 ALTER TABLE `item` DROP COLUMN `previous_path` ;
+ALTER TABLE `publish_package` DROP COLUMN `old_package_id` ;
+//************************** DELETE COLUMNS END **************************//
 
-//************************** DELETE TABLES AND COLUMNS END **************************//
+//************************* DROP PROCEDURES START *************************//
+DROP PROCEDURE IF EXISTS populateItemTarget
+//************************** DROP PROCEDURES END **************************//

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.4-to-5.0.0.5.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.4-to-5.0.0.5.sql
@@ -24,6 +24,11 @@ DROP PROCEDURE IF EXISTS duplicate_site ;
 	 - navigation_order_sequence
 
 	 Note: this procedure depends on populateItemParentId
+
+	 Updated here to populate the item_target table with the new items created from the duplication of the site
+	 and call populateItemParentId to update the parent_id of the items in the new site.
+
+	 It also drops references to removed columns last_published_on and previous_path
 **/
 CREATE PROCEDURE duplicate_site(IN sourceSiteId VARCHAR(50),
 									IN siteId VARCHAR(2000),

--- a/src/main/resources/crafter/studio/studio-upgrade-context.xml
+++ b/src/main/resources/crafter/studio/studio-upgrade-context.xml
@@ -212,4 +212,8 @@
 		<constructor-arg name="internalTextEncryptor" ref="internalTextEncryptor"/>
 	</bean>
 
+	<bean id="populateItemTargetTableUpgrader" scope="prototype" parent="dbScriptUpgrader"
+	      class="org.craftercms.studio.impl.v2.upgrade.operations.db.PopulateItemTargetTableUpgradeOperation">
+		<constructor-arg name="sitesService" ref="sitesServiceInternal"/>
+	</bean>
 </beans>

--- a/src/main/resources/crafter/studio/studio-upgrade-context.xml
+++ b/src/main/resources/crafter/studio/studio-upgrade-context.xml
@@ -216,4 +216,8 @@
 	      class="org.craftercms.studio.impl.v2.upgrade.operations.db.PopulateItemTargetTableUpgradeOperation">
 		<constructor-arg name="sitesService" ref="sitesServiceInternal"/>
 	</bean>
+
+	<bean id="checkContentTypeControllerUpgrader" scope="prototype" parent="upgradeOperation"
+	      class="org.craftercms.studio.impl.v2.upgrade.operations.site.ContentTypeControllerUpgradeOperation">
+	</bean>
 </beans>

--- a/src/main/resources/crafter/studio/upgrade/4.3.x/permission-mappings/permission-mappings-config-v4.3.0.0.xslt
+++ b/src/main/resources/crafter/studio/upgrade/4.3.x/permission-mappings/permission-mappings-config-v4.3.0.0.xslt
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+    <!-- to keep the right formatting -->
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <!-- copy all elements -->
+    <xsl:template match="node() | @*">
+        <!-- insert line breaks before comments -->
+        <xsl:if test="self::comment()">
+            <xsl:text>&#10;</xsl:text>
+        </xsl:if>
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+        <!-- insert line breaks after comments -->
+        <xsl:if test="self::comment()">
+            <xsl:text>&#10;</xsl:text>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Drop old unused permissions -->
+    <xsl:template match="permissions/role/rule/allowed-permissions/permission">
+        <xsl:choose>
+            <xsl:when test="text() = ('change_content_type', 'publish_clear_lock', 'rebuild_database')">
+                <!-- Remove -->
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                <xsl:copy-of select="@*"/>
+                <xsl:apply-templates/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/crafter/studio/upgrade/5.0.x/content-type/controller.groovy
+++ b/src/main/resources/crafter/studio/upgrade/5.0.x/content-type/controller.groovy
@@ -1,0 +1,11 @@
+import scripts.libs.CommonLifecycleApi;
+def contentLifecycleParams =[:];
+contentLifecycleParams.site = site;
+contentLifecycleParams.path = path;
+contentLifecycleParams.user = user;
+contentLifecycleParams.contentType = contentType;
+contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation;
+contentLifecycleParams.contentLoader = contentLoader;
+contentLifecycleParams.applicationContext = applicationContext;
+def controller = new CommonLifecycleApi(contentLifecycleParams);
+controller.execute();

--- a/src/main/resources/crafter/studio/upgrade/5.0.x/content-type/controller.groovy
+++ b/src/main/resources/crafter/studio/upgrade/5.0.x/content-type/controller.groovy
@@ -1,11 +1,11 @@
-import scripts.libs.CommonLifecycleApi;
-def contentLifecycleParams =[:];
-contentLifecycleParams.site = site;
-contentLifecycleParams.path = path;
-contentLifecycleParams.user = user;
-contentLifecycleParams.contentType = contentType;
-contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation;
-contentLifecycleParams.contentLoader = contentLoader;
-contentLifecycleParams.applicationContext = applicationContext;
-def controller = new CommonLifecycleApi(contentLifecycleParams);
-controller.execute();
+import scripts.libs.CommonLifecycleApi
+def contentLifecycleParams =[:]
+contentLifecycleParams.site = site
+contentLifecycleParams.path = path
+contentLifecycleParams.user = user
+contentLifecycleParams.contentType = contentType
+contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation
+contentLifecycleParams.contentLoader = contentLoader
+contentLifecycleParams.applicationContext = applicationContext
+def controller = new CommonLifecycleApi(contentLifecycleParams)
+controller.execute()

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -996,6 +996,16 @@ pipelines:
                         path: /config/studio/site-policy-config.xml
                         template: crafter/studio/upgrade/4.1.x/site-policy-config/site-policy-config-v4.1.2.xslt
                         commitDetails: Sync Studio version to 4.1.2
+            -   currentVersion: 4.1.2
+                nextVersion: 5.0-t
+            # Entry point for 5.0 upgrade
+            -   currentVersion: 5.0-t
+                nextVersion: 5.0.0.0
+                operations:
+                    -   type: checkContentTypeControllerUpgrader
+                        includedPaths:
+                            -   config/studio/content-types/.*/controller\.groovy
+                        commitDetails: Remove unnecessary controller.groovy files. Comment out custom scripts
 
     # Pipeline to upgrade blueprints
     blueprint:

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -740,9 +740,14 @@ pipelines:
             -   currentVersion: 5.0-t3
                 nextVersion: 5.0-t4
                 operations:
+                    -   type: populateItemTargetTableUpgrader
+                        spName: populateItemTarget
+            -   currentVersion: 5.0-t4
+                nextVersion: 5.0-t5
+                operations:
                     -   type: dbScriptUpgrader
                         filename: upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
-            -   currentVersion: 5.0-t4
+            -   currentVersion: 5.0-t5
                 nextVersion: 5.0.0.0
                 operations:
                     -   type: xsltFileUpgrader

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -716,8 +716,33 @@ pipelines:
                         filename: upgrade/4.2.x/4.2.0.16-to-4.2.0.17.sql
             -   currentVersion: 4.2.0.17
                 nextVersion: 5.0-t
+            -   currentVersion: 4.2.0.18
+                nextVersion: 5.0-t
+            -   currentVersion: 4.2.0.19
+                nextVersion: 5.0-t
+            -   currentVersion: 4.2.0.20
+                nextVersion: 5.0-t
+            -   currentVersion: 4.3.0.0
+                nextVersion: 5.0-t
+            -   currentVersion: 4.3.0.1
+                nextVersion: 5.0-t
             # Entry point for 5.0 upgrade
             -   currentVersion: 5.0-t
+                nextVersion: 5.0-t2
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/4.x-to-5.x/4.x-to-5.0.new-schema.sql
+            -   currentVersion: 5.0-t2
+                nextVersion: 5.0-t3
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/4.x-to-5.x/5.0-t2-to-5.0-t3.publisher-upgrade.sql
+            -   currentVersion: 5.0-t3
+                nextVersion: 5.0-t4
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/4.x-to-5.x/5.0-t3-to-5.0-t4.cleanup.sql
+            -   currentVersion: 5.0-t4
                 nextVersion: 5.0.0.0
                 operations:
                     -   type: xsltFileUpgrader

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -1250,6 +1250,15 @@ configurations:
                 -   currentVersion: 4.2.0.0
                     nextVersion: 4.2.0.1
                 -   currentVersion: 4.2.0.1
+                    nextVersion: 4.3.0.0
+                    operations:
+                        -   type: xsltFileUpgrader
+                            template: crafter/studio/upgrade/4.3.x/permission-mappings/permission-mappings-config-v4.3.0.0.xslt
+                            commitDetails: Remove unused permissions
+                -   currentVersion: 4.3.0.0
+                    nextVersion: 5.0-t
+                # Entry point for 5.0.x
+                -   currentVersion: 5.0-t
                     nextVersion: 5.0.0.0
                     operations:
                         -   type: xsltFileUpgrader

--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/permission-mappings-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/permission-mappings-config.xml
@@ -29,7 +29,7 @@
   View the sample for a good starting point.
 -->
 <permissions>
-	<version>5.0.0</version>
+	<version>5.0.0.0</version>
 	<role name="author">
 		<rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
 			<allowed-permissions>
@@ -103,7 +103,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>
@@ -149,7 +148,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/permission-mappings-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/permission-mappings-config.xml
@@ -29,7 +29,7 @@
   View the sample for a good starting point.
 -->
 <permissions>
-	<version>5.0.0</version>
+	<version>5.0.0.0</version>
 	<role name="author">
 		<rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
 			<allowed-permissions>
@@ -103,7 +103,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>
@@ -149,7 +148,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/permission-mappings-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/permission-mappings-config.xml
@@ -29,7 +29,7 @@
   View the sample for a good starting point.
 -->
 <permissions>
-	<version>5.0.0</version>
+	<version>5.0.0.0</version>
 	<role name="author">
 		<rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
 			<allowed-permissions>
@@ -103,7 +103,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>
@@ -149,7 +148,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/permission-mappings-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/permission-mappings-config.xml
@@ -29,7 +29,7 @@
   View the sample for a good starting point.
 -->
 <permissions>
-	<version>5.0.0</version>
+	<version>5.0.0.0</version>
 	<role name="author">
 		<rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
 			<allowed-permissions>
@@ -103,7 +103,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>
@@ -149,7 +148,6 @@
 				<permission>publish_cancel</permission>
 				<permission>folder_create</permission>
 				<permission>content_create</permission>
-				<permission>change_content_type</permission>
 				<permission>add_remote</permission>
 				<permission>list_remotes</permission>
 				<permission>pull_from_remote</permission>

--- a/src/test/java/org/craftercms/studio/XsltTest.java
+++ b/src/test/java/org/craftercms/studio/XsltTest.java
@@ -320,6 +320,12 @@ public class XsltTest {
 				new ClassPathResource("crafter/studio/upgrade/xslt/permission-mappings-config/4.2/4.2.0.0/expected.xml"),
 				emptyMap()
 			},
+			new Object[]{
+				new ClassPathResource("crafter/studio/upgrade/4.3.x/permission-mappings/permission-mappings-config-v4.3.0.0.xslt"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/input.xml"),
+				new ClassPathResource("crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/expected.xml"),
+				emptyMap()
+			},
 			new Object[] {
 				new ClassPathResource("crafter/studio/upgrade/5.0.x/system/global-permission-mappings-config-v5.0.0.0.xslt"),
 				new ClassPathResource("crafter/studio/upgrade/xslt/global-permission-mappings/5.0.0.0/input.xml"),

--- a/src/test/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperationTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperationTest.java
@@ -21,6 +21,7 @@ import org.craftercms.commons.upgrade.exception.UpgradeException;
 import org.craftercms.studio.api.v2.utils.StudioConfiguration;
 import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -43,6 +44,11 @@ public class ContentTypeControllerUpgradeOperationTest {
 	private StudioConfiguration studioConfiguration;
 	@InjectMocks
 	private ContentTypeControllerUpgradeOperation operation;
+
+	@Before
+	public void setUp() throws Exception {
+		operation.afterPropertiesSet();
+	}
 
 	@Test
 	public void testDefaultScript() throws IOException, UpgradeException {

--- a/src/test/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperationTest.java
+++ b/src/test/java/org/craftercms/studio/impl/v2/upgrade/operations/site/ContentTypeControllerUpgradeOperationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.craftercms.studio.impl.v2.upgrade.operations.site;
+
+import org.apache.commons.io.FileUtils;
+import org.craftercms.commons.upgrade.exception.UpgradeException;
+import org.craftercms.studio.api.v2.utils.StudioConfiguration;
+import org.craftercms.studio.impl.v2.upgrade.StudioUpgradeContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.craftercms.studio.api.v2.utils.StudioUtils.createTempFile;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ContentTypeControllerUpgradeOperationTest {
+	@Mock
+	private StudioConfiguration studioConfiguration;
+	@InjectMocks
+	private ContentTypeControllerUpgradeOperation operation;
+
+	@Test
+	public void testDefaultScript() throws IOException, UpgradeException {
+		ClassPathResource defaultScriptResource = new ClassPathResource("crafter/studio/upgrade/content-type/default/controller.groovy");
+		Path scriptFile = createTempFile("controller.groovy", defaultScriptResource.getInputStream());
+		try {
+			operation.updateFile(mock(StudioUpgradeContext.class), scriptFile);
+			Assert.assertFalse("Default script file was not deleted", Files.exists(scriptFile));
+		} finally {
+			FileUtils.deleteQuietly(scriptFile.toFile());
+		}
+	}
+
+	@Test
+	public void testCustomScript() throws UpgradeException, IOException, URISyntaxException {
+		ClassPathResource inputResource = new ClassPathResource("crafter/studio/upgrade/content-type/custom/input.groovy");
+		Path inputScriptFile = createTempFile("controller.groovy", inputResource.getInputStream());
+		operation.updateFile(mock(StudioUpgradeContext.class), inputScriptFile);
+		ClassPathResource expectedResource = new ClassPathResource("crafter/studio/upgrade/content-type/custom/expected.groovy");
+		Assert.assertEquals("Output file does not match ", -1, Files.mismatch(inputScriptFile, Paths.get(expectedResource.getURL().toURI())));
+	}
+
+}

--- a/src/test/resources/crafter/studio/upgrade/content-type/custom/expected.groovy
+++ b/src/test/resources/crafter/studio/upgrade/content-type/custom/expected.groovy
@@ -1,0 +1,37 @@
+/*
+  WARNING: This controller script was not updated automatically.
+  Please review and update it manually to ensure compatibility with the new version of Crafter Studio.
+  Original content commented out below
+*/
+///*
+// * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+// *
+// * This program is free software: you can redistribute it and/or modify
+// * it under the terms of the GNU General Public License version 3 as published by
+// * the Free Software Foundation.
+// *
+// * This program is distributed in the hope that it will be useful,
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// * GNU General Public License for more details.
+// *
+// * You should have received a copy of the GNU General Public License
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// */
+//
+//import scripts.libs.CommonLifecycleApi;
+//
+//def contentLifecycleParams =[:];
+//contentLifecycleParams.site = site;
+//contentLifecycleParams.path = path;
+//contentLifecycleParams.user = user;
+//contentLifecycleParams.contentType = contentType;
+//contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation;
+//contentLifecycleParams.contentLoader = contentLoader;
+//contentLifecycleParams.applicationContext = applicationContext;
+//
+//String test = 'This script contains custom code'
+//
+//def controller = new CommonLifecycleApi(contentLifecycleParams);
+//controller.execute();
+logger.error('This controller is disabled. Please review and upgrade to use the 5.0 content lifecycle API')

--- a/src/test/resources/crafter/studio/upgrade/content-type/custom/input.groovy
+++ b/src/test/resources/crafter/studio/upgrade/content-type/custom/input.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import scripts.libs.CommonLifecycleApi;
+
+def contentLifecycleParams =[:];
+contentLifecycleParams.site = site;
+contentLifecycleParams.path = path;
+contentLifecycleParams.user = user;
+contentLifecycleParams.contentType = contentType;
+contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation;
+contentLifecycleParams.contentLoader = contentLoader;
+contentLifecycleParams.applicationContext = applicationContext;
+
+String test = 'This script contains custom code'
+
+def controller = new CommonLifecycleApi(contentLifecycleParams);
+controller.execute();

--- a/src/test/resources/crafter/studio/upgrade/content-type/default/controller.groovy
+++ b/src/test/resources/crafter/studio/upgrade/content-type/default/controller.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import scripts.libs.CommonLifecycleApi;
+
+def contentLifecycleParams =[:];
+contentLifecycleParams.site = site;
+contentLifecycleParams.path = path;
+contentLifecycleParams.user = user;
+contentLifecycleParams.contentType = contentType;
+contentLifecycleParams.contentLifecycleOperation = contentLifecycleOperation;
+contentLifecycleParams.contentLoader = contentLoader;
+contentLifecycleParams.applicationContext = applicationContext;
+
+def controller = new CommonLifecycleApi(contentLifecycleParams);
+controller.execute();

--- a/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.2/4.2.0.0/input.xml
+++ b/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.2/4.2.0.0/input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+  ~ Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License version 3 as published by

--- a/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/expected.xml
+++ b/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/expected.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License version 3 as published by
+  * the Free Software Foundation.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<!-- permission-mappings-config.xml
+  This files contains the permissions mappings for the roles defined in
+  role-mappings-config.xml.
+  Permissions are defined per:
+  site > role > rule
+  Rules have a regex expression that govern the scope of the permissions assigned.
+  Absence of permissions means the permission is denied.
+  View the sample for a good starting point.
+-->
+<permissions>
+    <role name="author">
+        <rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>content_create</permission>
+                <permission>folder_create</permission>
+                <permission>content_copy</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="publisher">
+        <rule regex="/site/.*|/static-assets.*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>content_create</permission>
+                <permission>folder_create</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>content_copy</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex="^/site/(?!website/index\.xml)(.*)|/static-assets.*">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>get_publishing_queue</permission>
+                <permission>publish_by_commits</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="developer">
+        <rule regex="^/(?!site/website/index\.xml)(.*)">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>folder_create</permission>
+                <permission>content_create</permission>
+                <permission>add_remote</permission>
+                <permission>list_remotes</permission>
+                <permission>pull_from_remote</permission>
+                <permission>push_to_remote</permission>
+                <permission>remove_remote</permission>
+                <permission>site_status</permission>
+                <permission>resolve_conflict</permission>
+                <permission>site_diff_conflicted_file</permission>
+                <permission>commit_resolution</permission>
+                <permission>cancel_failed_pull</permission>
+                <permission>encryption_tool</permission>
+                <permission>content_copy</permission>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>install_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>remove_plugins</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>view_logs</permission>
+                <permission>audit_log</permission>
+                <permission>read_configuration</permission>
+                <permission>write_configuration</permission>
+                <permission>set_item_states</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="admin">
+        <rule regex="^/(?!site/website/index\.xml)(.*)">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>folder_create</permission>
+                <permission>content_create</permission>
+                <permission>add_remote</permission>
+                <permission>list_remotes</permission>
+                <permission>pull_from_remote</permission>
+                <permission>push_to_remote</permission>
+                <permission>remove_remote</permission>
+                <permission>site_status</permission>
+                <permission>resolve_conflict</permission>
+                <permission>site_diff_conflicted_file</permission>
+                <permission>commit_resolution</permission>
+                <permission>cancel_failed_pull</permission>
+                <permission>encryption_tool</permission>
+                <permission>unlock_repository</permission>
+                <permission>content_copy</permission>
+                <permission>repair_repository</permission>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>edit_site</permission>
+                <permission>list_plugins</permission>
+                <permission>install_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>item_unlock</permission>
+                <permission>remove_plugins</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>view_logs</permission>
+                <permission>start_stop_publisher</permission>
+                <permission>read_configuration</permission>
+                <permission>write_configuration</permission>
+                <permission>set_item_states</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="reviewer">
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>s3_read</permission>
+                <permission>webdav_read</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="*">
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>webdav_read</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+</permissions>

--- a/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/input.xml
+++ b/src/test/resources/crafter/studio/upgrade/xslt/permission-mappings-config/4.3/4.3.0.0/input.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License version 3 as published by
+  ~ the Free Software Foundation.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<!-- permission-mappings-config.xml
+
+  This files contains the permissions mappings for the roles defined in
+  role-mappings-config.xml.
+
+  Permissions are defined per:
+  site > role > rule
+
+  Rules have a regex expression that govern the scope of the permissions assigned.
+
+  Absence of permissions means the permission is denied.
+
+  View the sample for a good starting point.
+-->
+<permissions>
+    <role name="author">
+        <rule regex="/site/website/.*|/site/components(/.*)?|/static-assets(/.*)?">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>content_create</permission>
+                <permission>folder_create</permission>
+                <permission>content_copy</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="publisher">
+        <rule regex="/site/.*|/static-assets.*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>content_create</permission>
+                <permission>folder_create</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>content_copy</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex="^/site/(?!website/index\.xml)(.*)|/static-assets.*">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>get_publishing_queue</permission>
+                <permission>publish_by_commits</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="developer">
+        <rule regex="^/(?!site/website/index\.xml)(.*)">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>folder_create</permission>
+                <permission>content_create</permission>
+                <permission>change_content_type</permission>
+                <permission>add_remote</permission>
+                <permission>list_remotes</permission>
+                <permission>pull_from_remote</permission>
+                <permission>push_to_remote</permission>
+                <permission>rebuild_database</permission>
+                <permission>remove_remote</permission>
+                <permission>site_status</permission>
+                <permission>resolve_conflict</permission>
+                <permission>site_diff_conflicted_file</permission>
+                <permission>commit_resolution</permission>
+                <permission>cancel_failed_pull</permission>
+                <permission>encryption_tool</permission>
+                <permission>content_copy</permission>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>list_plugins</permission>
+                <permission>install_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>remove_plugins</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>view_logs</permission>
+                <permission>audit_log</permission>
+                <permission>read_configuration</permission>
+                <permission>write_configuration</permission>
+                <permission>set_item_states</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="admin">
+        <rule regex="^/(?!site/website/index\.xml)(.*)">
+            <allowed-permissions>
+                <permission>content_delete</permission>
+            </allowed-permissions>
+        </rule>
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>content_write</permission>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>folder_create</permission>
+                <permission>content_create</permission>
+                <permission>change_content_type</permission>
+                <permission>add_remote</permission>
+                <permission>list_remotes</permission>
+                <permission>pull_from_remote</permission>
+                <permission>push_to_remote</permission>
+                <permission>rebuild_database</permission>
+                <permission>remove_remote</permission>
+                <permission>site_status</permission>
+                <permission>resolve_conflict</permission>
+                <permission>site_diff_conflicted_file</permission>
+                <permission>commit_resolution</permission>
+                <permission>cancel_failed_pull</permission>
+                <permission>encryption_tool</permission>
+                <permission>publish_clear_lock</permission>
+                <permission>unlock_repository</permission>
+                <permission>content_copy</permission>
+                <permission>repair_repository</permission>
+                <permission>s3_read</permission>
+                <permission>s3_write</permission>
+                <permission>webdav_read</permission>
+                <permission>webdav_write</permission>
+                <permission>edit_site</permission>
+                <permission>list_plugins</permission>
+                <permission>install_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>item_unlock</permission>
+                <permission>remove_plugins</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>view_logs</permission>
+                <permission>start_stop_publisher</permission>
+                <permission>read_configuration</permission>
+                <permission>write_configuration</permission>
+                <permission>set_item_states</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="reviewer">
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>publish</permission>
+                <permission>cancel_publish</permission>
+                <permission>s3_read</permission>
+                <permission>webdav_read</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+                <permission>read_configuration</permission>
+                <permission>publish_by_commits</permission>
+                <permission>get_publishing_queue</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+    <role name="*">
+        <rule regex=".*">
+            <allowed-permissions>
+                <permission>s3_read</permission>
+                <permission>webdav_read</permission>
+                <permission>list_plugins</permission>
+                <permission>get_children</permission>
+                <permission>publish_status</permission>
+                <permission>content_read</permission>
+                <permission>content_search</permission>
+            </allowed-permissions>
+        </rule>
+    </role>
+</permissions>


### PR DESCRIPTION
Publisher-related UM scripts
https://github.com/craftercms/craftercms/issues/6766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-site/per-target population step to initialize publishing metadata during upgrade.
  - Per-site/per-content-type lifecycle logging accessible to lifecycle scripts.

- **Chores**
  - Adds publish-related DB schema, stored procedures, data-migration and cleanup upgrade scripts; relaxes two NOT NULL constraints to allow NULL commit/last-published values.
  - Expands upgrade pipelines and flags/customizes content-type controller scripts.
  - Removes change_content_type permission from several default roles.

- **Tests**
  - Adds/updates XSLT and content-type upgrade tests and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->