### PR TITLE
Prevent clearing locked_by on edit. Fix column name

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
@@ -45,7 +45,6 @@ public class Item {
 	private Person modifier;
 	private ZonedDateTime lastModifiedOn;
 	private ZonedDateTime lastPublishedOn;
-	private Person submitter;
 	private ZonedDateTime submittedOn;
 	private String label;
 	private String contentTypeId;
@@ -79,7 +78,6 @@ public class Item {
 		modifier = builder.modifier;
 		lastModifiedOn = builder.lastModifiedOn;
 		lastPublishedOn = builder.lastPublishedOn;
-		submitter = builder.submitter;
 		submittedOn = builder.submittedOn;
 		label = builder.label;
 		contentTypeId = builder.contentTypeId;
@@ -215,14 +213,6 @@ public class Item {
 		this.lastPublishedOn = lastPublishedOn;
 	}
 
-	public Person getSubmitter() {
-		return submitter;
-	}
-
-	public void setSubmitter(Person submitter) {
-		this.submitter = submitter;
-	}
-
 	public ZonedDateTime getSubmittedOn() {
 		return submittedOn;
 	}
@@ -343,7 +333,6 @@ public class Item {
 		private Person modifier;
 		private ZonedDateTime lastModifiedOn;
 		private ZonedDateTime lastPublishedOn;
-		public Person submitter;
 		public ZonedDateTime submittedOn;
 		private String label;
 		private String contentTypeId;
@@ -354,7 +343,6 @@ public class Item {
 		private long size;
 		private Long parentId = null;
 		private Long availableActions;
-		private String previousPath;
 		private int ignoredAsInt;
 		private boolean ignored;
 		private int childrenCount = 0;
@@ -378,7 +366,6 @@ public class Item {
 			clone.modifier = item.modifier;
 			clone.lastModifiedOn = item.lastModifiedOn;
 			clone.lastPublishedOn = item.lastPublishedOn;
-			clone.submitter = item.submitter;
 			clone.submittedOn = item.submittedOn;
 			clone.label = item.label;
 			clone.contentTypeId = item.contentTypeId;
@@ -507,11 +494,6 @@ public class Item {
 
 		public Builder withParentId(Long parentId) {
 			this.parentId = parentId;
-			return this;
-		}
-
-		public Builder withPreviousPath(String previousPath) {
-			this.previousPath = previousPath;
 			return this;
 		}
 

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -21,13 +21,14 @@
 <mapper namespace="org.craftercms.studio.api.v2.dal.ItemDAO">
 	<resultMap id="ItemMap" type="org.craftercms.studio.api.v2.dal.Item" autoMapping="true">
 		<id property="id" column="id"/>
-		<association property="modifier" column="modifier"
+		<result property="lastModifiedBy" column="last_modified_by"/>
+		<result property="createdBy" column="created_by"/>
+		<result property="lockedBy" column="locked_by"/>
+		<association property="modifier" column="last_modified_by"
 			     select="org.craftercms.studio.api.v2.dal.UserDAO.getPerson"/>
-		<association property="creator" column="creator"
+		<association property="creator" column="created_by"
 			     select="org.craftercms.studio.api.v2.dal.UserDAO.getPerson"/>
-		<association property="lockOwner" column="lock_owner"
-			     select="org.craftercms.studio.api.v2.dal.UserDAO.getPerson"/>
-		<association property="submitter" column="submitter"
+		<association property="lockOwner" column="locked_by"
 			     select="org.craftercms.studio.api.v2.dal.UserDAO.getPerson"/>
 	</resultMap>
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8273
Prevent dropping old `locked_by` value on item update. Fix column name
Remove references to old submitter property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Item responses now include lastModifiedBy, createdBy, and lockedBy fields for clearer user metadata.
* **Refactor**
  * Updated user metadata mapping for Items to improve consistency.
  * The submitter field has been removed from Item responses.
  * Builder/API surface no longer exposes previousPath-related setter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->