### PR TITLE
Fix item by path when only child is a level descriptor

### DIFF
--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -213,7 +213,7 @@
 
 	<sql id="detailedItemSelect">
 		SELECT i.*,
-				COUNT (DISTINCT IF(ichild.system_type = '${systemTypeLevelDescriptor}', NULL, ichild.id)) AS children_count
+				COUNT (DISTINCT ichild.id) AS children_count
 		FROM item i
 			INNER JOIN site s ON i.site_id = s.id
 			LEFT OUTER JOIN item ichild ON i.id = ichild.parent_id

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -213,7 +213,7 @@
 
 	<sql id="detailedItemSelect">
 		SELECT i.*,
-				COUNT (DISTINCT ichild.id) AS children_count
+				COUNT (DISTINCT IF(ichild.system_type = '${systemTypeLevelDescriptor}', NULL, ichild.id)) AS children_count
 		FROM item i
 			INNER JOIN site s ON i.site_id = s.id
 			LEFT OUTER JOIN item ichild ON i.id = ichild.parent_id
@@ -304,7 +304,6 @@
 						AND iPage.path = concat(ichild.path, '/index.xml')
 					)
 			)
-			AND ichild.system_type &lt;&gt; '${systemTypeLevelDescriptor}'
 		))
 	</sql>
 


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8088
Fix item by path when only child is a level descriptor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected child item counts to include certain structural/system-type items that were previously excluded, resulting in more accurate totals in lists and dashboards.
  * Adjusted child item filtering so previously omitted items of a specific type are now returned, ensuring complete results in listings and navigation.
  * Improves consistency between displayed child counts and the actual items shown to users across relevant views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->