### PR TITLE
Log DiskMonitor checking as debug

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/monitor/DiskMonitor.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/monitor/DiskMonitor.java
@@ -99,9 +99,9 @@ public class DiskMonitor implements InitializingBean {
 			logger.info("System is not ready, skipping disk usage check.");
 			return;
 		}
-		logger.info("Checking disk usage...");
+		logger.debug("Checking disk usage...");
 		calculateDiskStatus();
-		logger.info("Disk usage check completed successfully.");
+		logger.debug("Disk usage check completed successfully.");
 
 		if (diskStatus.isAlarm()) {
 			logger.debug("Disk usage in alarm state, triggering an alarm.");


### PR DESCRIPTION
Log DiskMonitor checking as debug
https://github.com/craftercms/craftercms/issues/8272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted logging levels in disk monitoring: routine status messages were moved from INFO to DEBUG. This reduces default log noise and storage usage, improving log clarity for operators. Disk usage calculations, thresholds, and alarm behavior remain unchanged. These messages now appear only when DEBUG logging is enabled. No user-facing changes in UI or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->