### PR TITLE
Drop states for folder items

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/Item.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by

--- a/src/main/java/org/craftercms/studio/api/v2/security/ContentItemPossibleActionsConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v2/security/ContentItemPossibleActionsConstants.java
@@ -83,7 +83,7 @@ public final class ContentItemPossibleActionsConstants {
 	public static final long CONFIGURATION = PUBLISH + PUBLISH_REQUEST;
 
 	public static final long FOLDER = CONTENT_COPY + CONTENT_CREATE + CONTENT_PASTE + CONTENT_RENAME + CONTENT_CUT +
-		CONTENT_UPLOAD + FOLDER_CREATE + CONTENT_DELETE + ITEM_UNLOCK;
+		CONTENT_UPLOAD + FOLDER_CREATE + CONTENT_DELETE;
 
 	public static final long USER = 0L;
 

--- a/src/main/java/org/craftercms/studio/api/v2/security/SemanticsAvailableActionsResolver.java
+++ b/src/main/java/org/craftercms/studio/api/v2/security/SemanticsAvailableActionsResolver.java
@@ -32,7 +32,7 @@ public interface SemanticsAvailableActionsResolver {
 	 *
 	 * @param username     user name to apply permissions
 	 * @param siteId       site identifier
-	 * @param detailedItem Item
+	 * @param detailedItem detailed content item to calculate available actions for
 	 * @return bitmap representing available actions
 	 */
 	long calculateContentItemAvailableActions(String username, String siteId, ContentItem detailedItem)

--- a/src/main/java/org/craftercms/studio/api/v2/security/SemanticsAvailableActionsResolver.java
+++ b/src/main/java/org/craftercms/studio/api/v2/security/SemanticsAvailableActionsResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -18,7 +18,6 @@ package org.craftercms.studio.api.v2.security;
 
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
-import org.craftercms.studio.api.v2.dal.Item;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 
 /**
@@ -31,22 +30,11 @@ public interface SemanticsAvailableActionsResolver {
 	/**
 	 * Calculate available actions for given content item
 	 *
-	 * @param username user name to apply permissions
-	 * @param siteId   site identifier
-	 * @param item     Item
-	 * @return bitmap representing available actions
-	 */
-	long calculateContentItemAvailableActions(String username, String siteId, Item item)
-		throws ServiceLayerException, UserNotFoundException;
-
-	/**
-	 * Calculate available actions for given content item
-	 *
 	 * @param username     user name to apply permissions
 	 * @param siteId       site identifier
 	 * @param detailedItem Item
 	 * @return bitmap representing available actions
 	 */
 	long calculateContentItemAvailableActions(String username, String siteId, ContentItem detailedItem)
-		throws ServiceLayerException, UserNotFoundException;
+			throws ServiceLayerException, UserNotFoundException;
 }

--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -347,7 +347,7 @@ public class SiteServiceImpl implements SiteService, ApplicationContextAware {
 		String label = new File(directory).getName();
 		Item item = itemService.instantiateItem(siteId, directory)
 			.withPreviewUrl(null)
-			.withState(NEW.value)
+			.withState(0)
 			.withLockedBy(null)
 			.withCreatedBy(userId)
 			.withCreatedOn(now)

--- a/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/site/SiteServiceImpl.java
@@ -347,7 +347,7 @@ public class SiteServiceImpl implements SiteService, ApplicationContextAware {
 		String label = new File(directory).getName();
 		Item item = itemService.instantiateItem(siteId, directory)
 			.withPreviewUrl(null)
-			.withState(0)
+			.withState(0L)
 			.withLockedBy(null)
 			.withCreatedBy(userId)
 			.withCreatedOn(now)

--- a/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepositoryImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/repository/GitContentRepositoryImpl.java
@@ -886,7 +886,7 @@ public class GitContentRepositoryImpl implements GitContentRepository, GitPublis
 	private void addEmptyFile(Repository repo, String siteId, String path) throws ServiceLayerException {
 		try {
 			File file = new File(repo.getDirectory().getParent(), path);
-			if (!file.createNewFile()) {
+			if (!file.exists() && !file.createNewFile()) {
 				logger.error("Failed to create file to site '{}' path '{}'", siteId, path);
 				throw new ServiceLayerException(format("Failed to create file to site '%s' path '%s'", siteId, path));
 			}

--- a/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
@@ -23,7 +23,6 @@ import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
-import org.craftercms.studio.api.v2.dal.Item;
 import org.craftercms.studio.api.v2.dal.ItemState;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 import org.craftercms.studio.api.v2.repository.blob.StudioBlobStore;
@@ -64,27 +63,19 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 	private ContentTypeService contentTypeService;
 
 	@Override
-	public long calculateContentItemAvailableActions(String username, String siteId, Item item)
-			throws ServiceLayerException, UserNotFoundException {
-		long userPermissionsBitmap = availableActionsResolver.getContentItemAvailableActions(username, siteId, item.getPath());
-		long systemTypeBitmap = getPossibleActionsForObject(item.getSystemType());
-		long workflowStateBitmap = getPossibleActionsForItemState(item.getState(),
-			hasUnlockPermission(item.getLockOwner(), item.getState(), siteId, item.getPath(), username));
-
-		long result = (userPermissionsBitmap & systemTypeBitmap) & workflowStateBitmap;
-		return applySpecialUseCaseFilters(username, siteId, item.getPath(), item.getMimeType(),
-				item.getSystemType(), item.getContentTypeId(), item.getState(), result);
-	}
-
-	@Override
 	public long calculateContentItemAvailableActions(String username, String siteId, ContentItem detailedItem)
 			throws ServiceLayerException, UserNotFoundException {
 		long userPermissionsBitmap = availableActionsResolver.getContentItemAvailableActions(username, siteId, detailedItem.getPath());
 		long systemTypeBitmap = getPossibleActionsForObject(detailedItem.getSystemType());
-		long workflowStateBitmap = getPossibleActionsForItemState(detailedItem.getState(),
-			hasUnlockPermission(detailedItem.getLockOwner(), detailedItem.getState(), siteId, detailedItem.getPath(), username));
 
-		long result = (userPermissionsBitmap & systemTypeBitmap) & workflowStateBitmap;
+		long result = userPermissionsBitmap & systemTypeBitmap;
+		if (!CONTENT_TYPE_FOLDER.equals(detailedItem.getSystemType())) {
+			long workflowStateBitmap = getPossibleActionsForItemState(detailedItem.getState(),
+					hasUnlockPermission(detailedItem.getLockOwner(), detailedItem.getState(), siteId, detailedItem.getPath(), username));
+
+			result &= workflowStateBitmap;
+		}
+
 		return applySpecialUseCaseFilters(username, siteId, detailedItem.getPath(), detailedItem.getMimeType(),
 				detailedItem.getSystemType(), detailedItem.getContentTypeId(),
 				detailedItem.getState(),

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -1151,7 +1151,6 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 */
 	protected Set<String> getMissingFoldersForCopyOrMove(String siteId, Collection<ContentLifecycleItem> lifecycleItems) {
 		return lifecycleItems.stream()
-				.filter(item -> item.sourcePath() == null)
 				.flatMap(item -> calculateMissingFolders(siteId, item.repoPath()).stream())
 				.collect(toSet());
 	}

--- a/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
@@ -272,16 +272,16 @@ public class ItemServiceInternalImpl implements ItemService {
 
 	@Override
 	public void persistItemAfterCreateFolder(String siteId, String folderPath, String folderName, Long parentId)
-		throws AuthenticationException {
+			throws AuthenticationException {
 		User userObj = SecurityUtils.getCurrentUser();
 		Item item = instantiateItem(siteId, folderPath)
-			.withLastModifiedBy(userObj.getId())
-			.withLastModifiedOn(DateUtils.getCurrentTime())
-			.withLabel(folderName)
-			.withParentId(parentId)
-			.build();
-		item.setState(ItemState.savedAndClosed(item.getState()));
-		item.setSystemType("folder");
+				.withLastModifiedBy(userObj.getId())
+				.withLastModifiedOn(DateUtils.getCurrentTime())
+				.withLabel(folderName)
+				.withParentId(parentId)
+				.withState(0L)
+				.build();
+		item.setSystemType(CONTENT_TYPE_FOLDER);
 		upsertEntry(item);
 	}
 

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.7-to-5.0.0.8.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.7-to-5.0.0.8.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+UPDATE item SET state = 0 WHERE system_type = 'folder' ;
+

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -816,6 +816,11 @@ pipelines:
                         # Version in the file name does not match. We are reusing the xslt from site upgrades
                         template: crafter/studio/upgrade/5.0.x/config/resolver-config/resolver-config-v5.0.0.1.xslt
                         commitDetails: Add support for relative page urls
+            -   currentVersion: 5.0.0.7
+                nextVersion: 5.0.0.8
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/5.0.0.7-to-5.0.0.8.sql
 
     # Pipeline to upgrade site repositories
     site:

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -372,7 +372,7 @@
 	<update id="moveItemInternal">
 		UPDATE item i INNER JOIN site s ON i.site_id = s.id
 		SET path = #{newPath},
-		i.state = (i.state | #{onStatesBitMap}) &amp; ~#{offStatesBitMap},
+		i.state = CASE WHEN i.system_type = '${systemTypeFolder}' THEN 0 ELSE (i.state | #{onStatesBitMap}) &amp; ~#{offStatesBitMap} END,
 		i.preview_url = IF(i.system_type = '${systemTypeFolder}', NULL, #{newPreviewUrl}),
 		i.last_modified_by = #{userId},
 		i.last_modified_on = NOW()
@@ -389,7 +389,9 @@
 		INSERT INTO item (site_id, path, preview_url, state, locked_by, created_by, created_on, last_modified_by,
 				  last_modified_on, label, content_type_id, system_type, mime_type, locale_code,
 				  translation_source_id, size, parent_id, ignored)
-		SELECT s.id, #{newPath} AS path, IF(i.system_type = '${systemTypeFolder}', NULL, #{previewUrl}) AS preview_url, ${state}, null, ${userId}, NOW(), ${userId},
+		SELECT s.id, #{newPath} AS path, IF(i.system_type = '${systemTypeFolder}', NULL, #{previewUrl}) AS preview_url,
+				CASE WHEN i.system_type = '${systemTypeFolder}' THEN 0 ELSE ${state} END,
+				null, ${userId}, NOW(), ${userId},
 				NOW(), IFNULL(#{label}, i.label) AS label, i.content_type_id, i.system_type, i.mime_type, i.locale_code,
 				i.translation_source_id, i.size, #{parentId}, i.ignored
 		FROM item i INNER JOIN site s ON i.site_id = s.id

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -351,6 +351,7 @@
 		<foreach collection="paths" item="path" index="index" open="(" separator="," close=")">
 			#{path}
 		</foreach>
+		AND system_type = '${systemTypeFolder}'
 	</update>
 
 	<update id="resetStatesBySiteAndPathBulk">
@@ -359,6 +360,7 @@
 		<foreach collection="paths" item="path" index="index" open="(" separator="," close=")">
 			#{path}
 		</foreach>
+		AND system_type = '${systemTypeFolder}'
 	</update>
 
 	<update id="updateStatesBySiteAndPathBulk">
@@ -367,6 +369,7 @@
 		<foreach collection="paths" item="path" index="index" open="(" separator="," close=")">
 			#{path}
 		</foreach>
+		AND system_type = '${systemTypeFolder}'
 	</update>
 
 	<update id="moveItemInternal">
@@ -524,6 +527,7 @@
 		<if test="statesBitMap != null">
 			AND (i.state &amp; #{statesBitMap}) &gt; 0
 		</if>
+		AND i.system_type = '${systemTypeFolder}'
 	</update>
 
 	<update id="updateNewPageChildren">
@@ -666,7 +670,10 @@
 		SET
 			path = REPLACE(path, #{previousPath}, #{newPath}),
 			locked_by = NULL,
-			state = (state | #{onStatesBitMap}) &amp; ~#{offStatesBitMap}
+			state = CASE
+					WHEN system_type = '${systemTypeFolder}' THEN 0
+					ELSE (state | #{onStatesBitMap}) &amp; ~#{offStatesBitMap}
+				END
 		WHERE
 			site_id = #{siteId}
 			AND (path = #{previousPath} OR path LIKE CONCAT(#{previousPath}, '/%'));

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/publish/PublishDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/publish/PublishDAO.xml
@@ -154,6 +154,7 @@
 		) AS updates
 		SET item.state = (item.state | updates.maskOn) &amp; ~updates.maskOff
 		WHERE item.id = updates.item_id
+		AND item.system_type &lt;&gt; '${systemTypeFolder}'
 	</update>
 
 	<insert id="insertItemPublishItems">


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7724
Drop states for folder items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Adjusted folder permissions to remove the unlock action.
  - Improved accuracy of available actions; workflow checks no longer applied to folders.
  - Standardized folder state handling across create, move/copy, and publish operations.
  - Prevented false errors when creating placeholder files if they already exist.
  - More reliable detection of missing folders during copy/move.

- Chores
  - Added upgrade path to 5.0.0.8, including a data update to normalize folder states.
  - Updated notices and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->