### PR TITLE
Make search connection pool configurable

### DIFF
--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -742,6 +742,10 @@ studio.search.timeout.socket: -1
 studio.search.threads: -1
 # The number of threads to use, if set to -1 the default will be used
 studio.search.keepAlive: false
+# The max total connections, if set to -1 the default will be used
+studio.search.maxTotalConnections: -1
+# The max connections per route, if set to -1 the default will be used
+studio.search.maxConnectionsPerRoute: -1
 # Suffix added to the name for authoring indexes
 studio.search.index.suffix: -authoring
 # Name of the field for paths

--- a/src/main/resources/crafter/studio/studio-config.yaml
+++ b/src/main/resources/crafter/studio/studio-config.yaml
@@ -740,7 +740,7 @@ studio.search.timeout.connect: -1
 studio.search.timeout.socket: -1
 # The number of threads to use, if set to -1 the default will be used
 studio.search.threads: -1
-# The number of threads to use, if set to -1 the default will be used
+# Whether to enable TCP keep-alive on search sockets (boolean)
 studio.search.keepAlive: false
 # The max total connections, if set to -1 the default will be used
 studio.search.maxTotalConnections: -1

--- a/src/main/resources/crafter/studio/studio-search-context.xml
+++ b/src/main/resources/crafter/studio/studio-search-context.xml
@@ -27,6 +27,8 @@
 		<property name="socketTimeout" value="#{studioConfiguration.getProperty('studio.search.timeout.socket')}"/>
 		<property name="threadCount" value="#{studioConfiguration.getProperty('studio.search.threads')}"/>
 		<property name="socketKeepAlive" value="#{studioConfiguration.getProperty('studio.search.keepAlive')}"/>
+		<property name="maxTotalConnections" value="#{studioConfiguration.getProperty('studio.search.maxTotalConnections')}"/>
+		<property name="maxConnectionsPerRoute" value="#{studioConfiguration.getProperty('studio.search.maxConnectionsPerRoute')}"/>
 	</bean>
 
 	<bean id="authoringSearchService" class="org.craftercms.studio.impl.v2.service.search.PermissionAwareSearchService">


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8344
Make search connection pool configurable

Notice this PR is dependent on https://github.com/craftercms/search/pull/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added tunable search connection settings and a clearer keep-alive description in configuration.
  - Introduced configurable connection pooling limits (now adjustable, defaults set for high concurrency).
  - Aims to improve search stability and responsiveness under heavy load and provide operators clearer configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->