### PR TITLE
Improve repository/unlock API response and error handling

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/exception/repository/RepositoryNotFoundException.java
+++ b/src/main/java/org/craftercms/studio/api/v2/exception/repository/RepositoryNotFoundException.java
@@ -14,30 +14,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.craftercms.studio.model.rest;
+package org.craftercms.studio.api.v2.exception.repository;
 
-import org.craftercms.commons.validation.annotations.param.ValidSiteId;
 import org.craftercms.studio.api.v1.constant.GitRepositories;
+import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 
-public class UnlockRepositoryRequest {
+import static java.lang.String.format;
 
-	@ValidSiteId
-	private String siteId;
-	private GitRepositories repositoryType;
-
-	public String getSiteId() {
-		return siteId;
-	}
-
-	public void setSiteId(String siteId) {
-		this.siteId = siteId;
-	}
-
-	public GitRepositories getRepositoryType() {
-		return repositoryType;
-	}
-
-	public void setRepositoryType(GitRepositories repositoryType) {
-		this.repositoryType = repositoryType;
+/**
+ * Extension of {@link ServiceLayerException} thrown when a repository is not found.
+ */
+public class RepositoryNotFoundException extends ServiceLayerException {
+	public RepositoryNotFoundException(String siteId, GitRepositories repoType) {
+		super(format("Repository of type '%s' not found for site '%s'", repoType, siteId));
 	}
 }

--- a/src/main/java/org/craftercms/studio/api/v2/service/repository/RepositoryManagementService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/repository/RepositoryManagementService.java
@@ -160,9 +160,10 @@ public interface RepositoryManagementService {
 	 *
 	 * @param siteId         site identifier, if null or empty it is global repository
 	 * @param repositoryType repository type (GLOBAL, SANDBOX, PUBLISHED)
-	 * @return true if successful
+	 * @throws SiteNotFoundException if the site is not found
+	 * @throws ServiceLayerException if there is any error unlocking the repository
 	 */
-	boolean unlockRepository(String siteId, GitRepositories repositoryType) throws SiteNotFoundException;
+	void unlockRepository(String siteId, GitRepositories repositoryType) throws ServiceLayerException;
 
 	/**
 	 * Checks if a given Git repository is corrupted

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/ExceptionHandlers.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/ExceptionHandlers.java
@@ -50,6 +50,7 @@ import org.craftercms.studio.api.v2.exception.publish.InvalidPackageStateExcepti
 import org.craftercms.studio.api.v2.exception.publish.PackageAlreadyApprovedException;
 import org.craftercms.studio.api.v2.exception.publish.PublishPackageNotFoundException;
 import org.craftercms.studio.api.v2.exception.repository.InvalidRemoteException;
+import org.craftercms.studio.api.v2.exception.repository.RepositoryNotFoundException;
 import org.craftercms.studio.api.v2.exception.security.ActionsDeniedException;
 import org.craftercms.studio.api.v2.exception.security.PeerReviewCheckException;
 import org.craftercms.studio.model.rest.ApiResponse;
@@ -83,8 +84,7 @@ import static org.craftercms.studio.controller.rest.v2.ResultConstants.*;
 import static org.craftercms.studio.model.rest.ApiResponse.INVALID_PARAMS;
 import static org.slf4j.event.Level.DEBUG;
 import static org.slf4j.event.Level.ERROR;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.*;
 
 /**
  * Controller advice that handles exceptions thrown by API 2 REST controllers.
@@ -637,6 +637,13 @@ public class ExceptionHandlers {
 		result.setResponse(response);
 		result.setEntity(RESULT_KEY_PACKAGE, e.getPackageId());
 		return result;
+	}
+
+	@ExceptionHandler
+	@ResponseStatus(NOT_FOUND)
+	public Result handleException(HttpServletRequest request, RepositoryNotFoundException e) {
+		ApiResponse response = new ApiResponse(ApiResponse.REPOSITORY_NOT_FOUND);
+		return handleExceptionInternal(request, e, response);
 	}
 
 	@ExceptionHandler(InvalidRemoteException.class)

--- a/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/RepositoryManagementController.java
@@ -192,15 +192,10 @@ public class RepositoryManagementController {
 	}
 
 	@PostMapping(UNLOCK)
-	public Result unlockRepository(@Valid @RequestBody UnlockRepositoryRequest unlockRepositoryRequest) throws SiteNotFoundException {
-		boolean success = repositoryManagementService.unlockRepository(unlockRepositoryRequest.getSiteId(),
-			unlockRepositoryRequest.getRepositoryType());
+	public Result unlockRepository(@Valid @RequestBody UnlockRepositoryRequest unlockRepositoryRequest) throws ServiceLayerException {
+		repositoryManagementService.unlockRepository(unlockRepositoryRequest.getSiteId(), unlockRepositoryRequest.getRepositoryType());
 		Result result = new Result();
-		if (success) {
-			result.setResponse(OK);
-		} else {
-			result.setResponse(INTERNAL_SYSTEM_FAILURE);
-		}
+		result.setResponse(OK);
 		return result;
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/repository/RepositoryManagementServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/repository/RepositoryManagementServiceImpl.java
@@ -140,9 +140,9 @@ public class RepositoryManagementServiceImpl implements RepositoryManagementServ
 	@Override
 	@RequireSiteExists
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_UNLOCK_REPO)
-	public boolean unlockRepository(@SiteId String siteId,
-					GitRepositories repositoryType) throws SiteNotFoundException {
-		return repositoryManagementServiceInternal.unlockRepository(siteId, repositoryType);
+	public void unlockRepository(@SiteId String siteId,
+					GitRepositories repositoryType) throws ServiceLayerException {
+		repositoryManagementServiceInternal.unlockRepository(siteId, repositoryType);
 	}
 
 	@Override

--- a/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/repository/internal/RepositoryManagementServiceInternalImpl.java
@@ -35,6 +35,7 @@ import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
 import org.craftercms.studio.api.v2.event.site.SyncFromRepoEvent;
 import org.craftercms.studio.api.v2.exception.PullFromRemoteConflictException;
 import org.craftercms.studio.api.v2.exception.content.ContentInPublishQueueException;
+import org.craftercms.studio.api.v2.exception.repository.RepositoryNotFoundException;
 import org.craftercms.studio.api.v2.repository.GitContentRepository;
 import org.craftercms.studio.api.v2.repository.RetryingRepositoryOperationFacade;
 import org.craftercms.studio.api.v2.service.audit.AuditService;
@@ -72,10 +73,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.lang.NonNull;
 
-import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1047,13 +1045,20 @@ public class RepositoryManagementServiceInternalImpl implements RepositoryManage
 	}
 
 	@Override
-	public boolean unlockRepository(String siteId, GitRepositories repositoryType) {
-		boolean toRet = false;
+	public void unlockRepository(String siteId, GitRepositories repositoryType) throws ServiceLayerException {
 		Repository repo = gitRepositoryHelper.getRepository(siteId, repositoryType);
-		if (Objects.nonNull(repo)) {
-			toRet = FileUtils.deleteQuietly(Paths.get(repo.getDirectory().getAbsolutePath(), LOCK_FILE).toFile());
+		if (!Objects.nonNull(repo)) {
+			throw new RepositoryNotFoundException(siteId, repositoryType);
 		}
-		return toRet;
+		File lockFile = Paths.get(repo.getDirectory().getAbsolutePath(), LOCK_FILE).toFile();
+		if (!lockFile.exists()) {
+			logger.debug("Lock file does not exist, nothing to unlock for site '{}' repository type '{}'", siteId, repositoryType);
+			return;
+		}
+		logger.debug("Unlocking repository for site '{}' repository type '{}'", siteId, repositoryType);
+		if (!FileUtils.deleteQuietly(lockFile) && lockFile.exists()) {
+			throw new ServiceLayerException("Failed to delete lock file: " + lockFile);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/craftercms/studio/model/rest/ApiResponse.java
+++ b/src/main/java/org/craftercms/studio/model/rest/ApiResponse.java
@@ -158,6 +158,8 @@ public class ApiResponse {
 		new ApiResponse(12007, "Remote repository authentication failed",
 			"Recreate the remote repository with the correct authentication credentials " +
 				"and make sure you have write access.", StringUtils.EMPTY);
+	public static final ApiResponse REPOSITORY_NOT_FOUND = new ApiResponse(12008, "Repository not found",
+			"Check if you sent in the right repository type and site id", StringUtils.EMPTY);
 
 	// 40000 - 41000
 	public static final ApiResponse MARKETPLACE_NOT_INITIALIZED =


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1133
Improve repository/unlock API response and error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unlock repository now returns 200 OK on success; failures are communicated via standardized errors.
  - Added a specific 404 “Repository not found” response with code 12008 and guidance for correcting repository type or site ID.
- Chores
  - Relaxed validation for unlock requests: siteId no longer requires a non-empty value, while still being validated as a valid site ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->