### PR TITLE
Return 404 instead of 500 on content not found for dependant items API

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
@@ -97,6 +97,7 @@ public interface DependencyService {
 	 * @param siteId site identifier
 	 * @param path   path to get dependent items for
 	 * @return list of {@link LightItem} dependent on given path
+	 * @throws ContentNotFoundException if the item at the given path does not exist
 	 */
 	List<LightItem> getDependentItems(String siteId, String path) throws ContentNotFoundException;
 

--- a/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/dependency/DependencyService.java
@@ -98,7 +98,7 @@ public interface DependencyService {
 	 * @param path   path to get dependent items for
 	 * @return list of {@link LightItem} dependent on given path
 	 */
-	List<LightItem> getDependentItems(String siteId, String path);
+	List<LightItem> getDependentItems(String siteId, String path) throws ContentNotFoundException;
 
 	/**
 	 * Get item specific dependencies for given path

--- a/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/dependency/DependencyServiceImpl.java
@@ -19,6 +19,7 @@ package org.craftercms.studio.impl.v2.service.dependency;
 import org.craftercms.commons.security.permissions.DefaultPermission;
 import org.craftercms.commons.security.permissions.annotations.HasPermission;
 import org.craftercms.commons.security.permissions.annotations.ProtectedResourceId;
+import org.craftercms.studio.api.v1.exception.ContentNotFoundException;
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.service.dependency.DependencyResolver;
@@ -86,7 +87,7 @@ public class DependencyServiceImpl implements DependencyService {
 	@RequireContentExists
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
 	public List<LightItem> getDependentItems(@SiteId String siteId,
-						      @ContentPath String path) {
+						      @ContentPath String path) throws ContentNotFoundException {
 		return dependencyServiceInternal.getDependentItems(siteId, path);
 	}
 


### PR DESCRIPTION
Return 404 instead of 500 on content not found for dependant items API
https://github.com/craftersoftware/craftercms/issues/1047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved handling when viewing content dependencies that no longer exist, preventing unexpected errors and providing clearer feedback to users.
  - Error messages and recovery flows updated for missing dependent items to reduce confusion and guide next steps.
  - Increased stability and predictability for dependency-related actions when items are removed.
  - More consistent responses in edge cases, reducing interruptions and improving reliability across dependency views and operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->