### PR TITLE
Make previous_path reset if renamed back to original published path. …

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
@@ -228,6 +228,7 @@ public interface ItemDAO {
     void moveItem(@Param(SITE_ID) String siteId, @Param(OLD_PATH) String oldPath, @Param(NEW_PATH) String newPath,
                   @Param(PARENT_ID) Long parentId, @Param(OLD_PREVIEW_URL) String oldPreviewUrl,
                   @Param(NEW_PREVIEW_URL) String newPreviewUrl, @Param(LABEL) String label,
+                  @Param(NEW_MASK) long newMask,
                   @Param(ON_STATES_BIT_MAP) long onStatesBitMap,
                   @Param(OFF_STATES_BIT_MAP) long offStatesBitMap);
 

--- a/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/item/internal/ItemServiceInternalImpl.java
@@ -352,7 +352,7 @@ public class ItemServiceInternalImpl implements ItemServiceInternal {
         String oldPreviewUrl = getBrowserUrl(siteId, oldPath);
         String newPreviewUrl = getBrowserUrl(siteId, newPath);
         retryingDatabaseOperationFacade.retry(() ->
-                itemDao.moveItem(siteId, oldPath, newPath, parentId, oldPreviewUrl, newPreviewUrl, label,
+                itemDao.moveItem(siteId, oldPath, newPath, parentId, oldPreviewUrl, newPreviewUrl, label, NEW.value,
                         SAVE_AND_CLOSE_ON_MASK, SAVE_AND_CLOSE_OFF_MASK));
     }
 

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -1033,7 +1033,7 @@
         SET path = #{newPath},
             i.state = (i.state | #{onStatesBitMap}) &amp; ~#{offStatesBitMap},
             i.preview_url = REPLACE(i.preview_url, #{oldPreviewUrl}, #{newPreviewUrl}),
-            i.previous_path = IFNULL(i.previous_path, #{oldPath})
+            i.previous_path = IF((i.state &amp; #{newMask}) > 0, NULL, IF(i.previous_path = #{newPath}, NULL, IFNULL(i.previous_path, #{oldPath})))
         <if test="label != null">
             , i.label = #{label}
         </if>


### PR DESCRIPTION
Make previous_path reset if renamed back to original published path. Prevent NEW items from having a previous_path
https://github.com/craftercms/craftercms/issues/8354