### PR TITLE
Enforce max length 500 for publish package comments

### DIFF
--- a/src/main/java/org/craftercms/studio/model/rest/publish/PublishPackageRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/publish/PublishPackageRequest.java
@@ -43,6 +43,7 @@ public class PublishPackageRequest {
 	private boolean requestApproval;
 	private boolean publishAll;
 	@NotEmpty
+	@Size(max = 500)
 	private String comment;
 	@NotEmpty
 	@Size(max = PublishService.PACKAGE_TITLE_MAX_LENGTH)

--- a/src/main/java/org/craftercms/studio/model/rest/workflow/ReviewPackageRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/workflow/ReviewPackageRequestBody.java
@@ -19,6 +19,7 @@ package org.craftercms.studio.model.rest.workflow;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.craftercms.studio.impl.v2.utils.SanitizerUtil;
 
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.List;
 public class ReviewPackageRequestBody {
 
 	@NotBlank
+	@Size(max = 500)
 	private String comment;
 	@NotEmpty
 	private List<@NotNull Long> packageIds;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1181
Enforce max length 500 for publish package comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added validation to comment fields across publishing and review workflows. Comments are now limited to a maximum of 500 characters to maintain data consistency and system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->