### PR TITLE
Bugfix/1180 eLock sandbox repository on publish package cancellation to prevent issues with item processing state updates

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/service/GeneralLockService.java
+++ b/src/main/java/org/craftercms/studio/api/v1/service/GeneralLockService.java
@@ -33,16 +33,6 @@ public interface GeneralLockService {
 	void lockContentItem(String siteId, String path);
 
 	/**
-	 * Try to lock item for synchronized access. If lock obtained returns true, otherwise false. Does not block
-	 * thread if not available lock.
-	 *
-	 * @param siteId
-	 * @param path
-	 * @return
-	 */
-	boolean tryLockContentItem(String siteId, String path);
-
-	/**
 	 * Release lock on content item.
 	 *
 	 * @param siteId site identifier

--- a/src/main/java/org/craftercms/studio/api/v2/dal/publish/PublishDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/publish/PublishDAO.java
@@ -335,16 +335,16 @@ public interface PublishDAO {
 													@Param(PublishDAO.ITEM_SUCCESS_STATE) long itemSuccessState);
 
 	/**
-	 * Persist changes to a cancelled or rejected publish package.
+	 * Persist changes to a cancelled, approved or rejected publish package.
 	 * This will update the package in the db and update the state bits for the items in the package.
-	 * Then imte state bits will be recalculated for affected publish_items
+	 * Then item state bits will be recalculated for affected publish_items
 	 * in the package, considering that the affected items might be part of other submitted packages.
 	 *
 	 * @param publishPackage the package to cancel
 	 * @param liveTarget     the live target for this site
 	 */
 	@Transactional
-	default void cancelPackage(final PublishPackage publishPackage, final String liveTarget) {
+	default void reviewPackage(final PublishPackage publishPackage, final String liveTarget) {
 		updatePackage(publishPackage);
 		updateItemStateBits(publishPackage.getId(), 0, CANCEL_PUBLISH_PACKAGE_OFF_MASK);
 		recalculateItemStateBits(publishPackage.getId(), liveTarget);

--- a/src/main/java/org/craftercms/studio/impl/v1/service/GeneralLockServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/GeneralLockServiceImpl.java
@@ -122,11 +122,6 @@ public class GeneralLockServiceImpl implements GeneralLockService {
 	}
 
 	@Override
-	public boolean tryLockContentItem(String siteId, String path) {
-		return tryLock(generateContentItemKey(siteId, path));
-	}
-
-	@Override
 	public void unlockContentItem(String siteId, String path) {
 		unlock(generateContentItemKey(siteId, path));
 	}

--- a/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
@@ -22,6 +22,7 @@ import org.craftercms.studio.api.v1.exception.security.AuthenticationException;
 import org.craftercms.studio.api.v1.service.GeneralLockService;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.dal.AuditLog;
+import org.craftercms.studio.api.v2.dal.RetryingDatabaseOperationFacade;
 import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.dal.User;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
@@ -54,6 +55,7 @@ import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalSt
 import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.REJECTED;
 import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.CANCELLED;
 import static org.craftercms.studio.api.v2.utils.StudioUtils.getPublishPackageLockKey;
+import static org.craftercms.studio.api.v2.utils.StudioUtils.getSandboxRepoLockKey;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getAuthentication;
 import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUser;
 
@@ -69,6 +71,7 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 	private PublishDAO publishDao;
 	private ServicesConfig servicesConfig;
 	private ApplicationEventPublisher eventPublisher;
+	private RetryingDatabaseOperationFacade retryingDatabaseOperationFacade;
 
 	@Override
 	public int getItemStatesTotal(String siteId, String path, Long states) {
@@ -111,12 +114,18 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 
 	@Override
 	public void cancelPackages(final String siteId, Collection<Long> packageIds, String comment)
-		throws ServiceLayerException, AuthenticationException {
-		for (Long packageId : packageIds) {
-			doReviewPackage(siteId, packageId, p -> {
-				p.setPackageState(CANCELLED.value);
-				p.setReviewerComment(comment);
-			}, OPERATION_CANCEL_PUBLISH_PACKAGE, WorkflowEvent.WorkFlowEventType.CANCEL);
+			throws ServiceLayerException, AuthenticationException {
+		String sandboxRepoLockKey = getSandboxRepoLockKey(siteId);
+		generalLockService.lock(sandboxRepoLockKey);
+		try {
+			for (Long packageId : packageIds) {
+				doReviewPackage(siteId, packageId, p -> {
+					p.setPackageState(CANCELLED.value);
+					p.setReviewerComment(comment);
+				}, OPERATION_CANCEL_PUBLISH_PACKAGE, WorkflowEvent.WorkFlowEventType.CANCEL);
+			}
+		} finally {
+			generalLockService.unlock(sandboxRepoLockKey);
 		}
 	}
 
@@ -166,9 +175,14 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 			packageReview.reviewPackage(publishPackage);
 			publishPackage.setReviewedOn(now());
 			publishPackage.setReviewerId(user.getId());
-			publishDao.cancelPackage(publishPackage, servicesConfig.getLiveEnvironment(siteId));
 
-			createUpdateStatePackageAuditLogEntry(publishPackage, user.getUsername(), operation);
+			String liveTarget = servicesConfig.getLiveEnvironment(siteId);
+			final PublishPackage finalPublishPackage = publishPackage;
+			retryingDatabaseOperationFacade.retry(() ->
+					publishDao.reviewPackage(finalPublishPackage, liveTarget)
+			);
+
+			createUpdateStatePackageAuditLogEntry(finalPublishPackage, user.getUsername(), operation);
 
 			activityStreamService.insertActivity(site.getId(), user.getId(),
 				operation, DateUtils.getCurrentTime(), null, String.valueOf(packageId));
@@ -231,6 +245,10 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 	@Override
 	public void setApplicationEventPublisher(@NotNull final ApplicationEventPublisher applicationEventPublisher) {
 		this.eventPublisher = applicationEventPublisher;
+	}
+
+	public void setRetryingDatabaseOperationFacade(final RetryingDatabaseOperationFacade retryingDatabaseOperationFacade) {
+		this.retryingDatabaseOperationFacade = retryingDatabaseOperationFacade;
 	}
 
 	private interface PackageReview {

--- a/src/main/java/org/craftercms/studio/impl/v2/sync/SyncFromRepositoryTask.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/sync/SyncFromRepositoryTask.java
@@ -319,7 +319,10 @@ public class SyncFromRepositoryTask implements ApplicationEventPublisherAware {
 			publishPackage.setReviewerComment(studioConfiguration
 				.getProperty(REPO_SYNC_CANCELLED_PACKAGE_COMMENT, String.class, DEFAULT_CANCELLED_PACKAGE_COMMENT));
 			publishPackage.setReviewedOn(now());
-			publishDao.cancelPackage(publishPackage, servicesConfig.getLiveEnvironment(siteId));
+			String liveTarget = servicesConfig.getLiveEnvironment(siteId);
+			retryingDatabaseOperationFacade.retry(() ->
+					publishDao.reviewPackage(publishPackage, liveTarget)
+			);
 			createCancelPackageAuditLogEntry(publishPackage);
 			eventPublisher.publishEvent(new WorkflowEvent(siteId, publishPackage.getId(), WorkflowEvent.WorkFlowEventType.CANCEL));
 		} finally {

--- a/src/main/resources/crafter/studio/studio-services-context.xml
+++ b/src/main/resources/crafter/studio/studio-services-context.xml
@@ -551,6 +551,7 @@
 		<property name="auditService" ref="auditServiceInternal"/>
 		<property name="publishDao" ref="publishDao"/>
 		<property name="servicesConfig" ref="cstudioServicesConfig"/>
+		<property name="retryingDatabaseOperationFacade" ref="studio.retryingDatabaseOperationFacade"/>
 	</bean>
 
 	<bean id="studio.activityStreamService"


### PR DESCRIPTION
Lock sandbox repository on publish package cancellation to prevent issues with item processing state updates
https://github.com/craftersoftware/craftercms/issues/1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reliability of package review operations with automatic retry mechanism for database transactions, reducing transient failures.

* **Refactor**
  * Simplified locking API by removing non-blocking lock attempt method; only blocking operations now available.
  * Renamed package cancellation method to clarify its application to multiple workflow states (cancelled, approved, rejected).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->