### PR TITLE
Add index.xml to page dependencies if missing

### DIFF
--- a/src/main/resources/crafter/studio/upgrade/5.0.x/config/resolver-config/resolver-config-v5.0.0.1.xslt
+++ b/src/main/resources/crafter/studio/upgrade/5.0.x/config/resolver-config/resolver-config-v5.0.0.1.xslt
@@ -50,7 +50,7 @@
 					<xsl:element name="transforms">
 						<xsl:element name="transform">
 							<xsl:element name="match">
-								<xsl:text>href=["'](\/[^"'?#]+)([^"']*)["']</xsl:text>
+								<xsl:text>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</xsl:text>
 							</xsl:element>
 							<xsl:element name="replace">
 								<xsl:text>/site/website$1</xsl:text>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/dependency/resolver-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/1000_website_editorial/config/studio/dependency/resolver-config.xml
@@ -44,7 +44,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -137,7 +138,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -229,7 +231,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/dependency/resolver-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/2000_headless_store/config/studio/dependency/resolver-config.xml
@@ -44,7 +44,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -137,7 +138,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -229,7 +231,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/dependency/resolver-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/4000_empty/config/studio/dependency/resolver-config.xml
@@ -44,7 +44,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -137,7 +138,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -229,7 +231,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>

--- a/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/dependency/resolver-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/blueprints/5000_headless_blog/config/studio/dependency/resolver-config.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License version 3 as published by
-  ~ the Free Software Foundation.
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License version 3 as published by
+  * the Free Software Foundation.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
 <!-- resolver-config.xml
@@ -44,7 +44,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -137,7 +138,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -229,7 +231,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>

--- a/src/main/webapp/repo-bootstrap/global/configuration/dependency/resolver-config.xml
+++ b/src/main/webapp/repo-bootstrap/global/configuration/dependency/resolver-config.xml
@@ -44,7 +44,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -137,7 +138,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -229,7 +231,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>

--- a/src/test/resources/crafter/studio/upgrade/xslt/resolver-config/5.0/5.0.0.1/expected.xml
+++ b/src/test/resources/crafter/studio/upgrade/xslt/resolver-config/5.0/5.0.0.1/expected.xml
@@ -43,7 +43,7 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -136,7 +136,7 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>
@@ -228,7 +228,8 @@
 							<find-regex>href=["'](?!http|https|ftp|mailto|tel|#|javascript|\/static-assets\/|\/site\/|\/templates\/|\/config\/|\/scripts\/|\/\/)(\/[^"']+)["']</find-regex>
 							<transforms>
 								<transform>
-									<match>href=["'](\/[^"'?#]+)([^"']*)["']</match>
+									<!-- This will match the link so the first group contains drops trailing slash or "index.xml" -->
+									<match>href=["'](\/((?!index\.xml)[^"'?#])+((?!index\.xml)[^"'?#\/])+)([^"']*)["']</match>
 									<replace>/site/website$1</replace>
 								</transform>
 							</transforms>


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8072
Add index.xml to page dependencies if missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined link dependency resolution patterns to properly exclude and handle index.xml paths, improving URL pattern matching accuracy across website configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->