### PR TITLE
Enforce max length for publish package comments. Cleanup

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/publish/PublishService.java
@@ -46,6 +46,7 @@ import java.util.List;
 public interface PublishService {
 
 	int PACKAGE_TITLE_MAX_LENGTH = 200;
+	int PACKAGE_COMMENT_MAX_LENGTH = 500;
 
 	/**
 	 * Get total number of publish packages for given search parameters

--- a/src/main/java/org/craftercms/studio/model/rest/content/DeleteRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/content/DeleteRequestBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -21,11 +21,12 @@ import jakarta.validation.constraints.Size;
 import org.craftercms.commons.validation.annotations.param.EsapiValidatedParam;
 import org.craftercms.commons.validation.annotations.param.ValidExistingContentPath;
 import org.craftercms.commons.validation.annotations.param.ValidateSecurePathParam;
-import org.craftercms.studio.api.v2.service.publish.PublishService;
 
 import java.util.Set;
 
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.SITE_ID;
+import static org.craftercms.studio.api.v2.service.publish.PublishService.PACKAGE_COMMENT_MAX_LENGTH;
+import static org.craftercms.studio.api.v2.service.publish.PublishService.PACKAGE_TITLE_MAX_LENGTH;
 
 /**
  * Request body for deleting content items.
@@ -39,8 +40,9 @@ public class DeleteRequestBody {
 
 	// title and comment are used to create a publish package for the delete
 	@NotEmpty
-	@Size(max = PublishService.PACKAGE_TITLE_MAX_LENGTH)
+	@Size(max = PACKAGE_TITLE_MAX_LENGTH)
 	private String title;
+	@Size(max = PACKAGE_COMMENT_MAX_LENGTH)
 	private String comment;
 
 	public String getSiteId() {

--- a/src/main/java/org/craftercms/studio/model/rest/publish/PublishPackageRequest.java
+++ b/src/main/java/org/craftercms/studio/model/rest/publish/PublishPackageRequest.java
@@ -20,7 +20,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.craftercms.commons.validation.annotations.param.EsapiValidatedParam;
-import org.craftercms.studio.api.v2.service.publish.PublishService;
 import org.craftercms.studio.api.v2.service.publish.PublishService.PublishRequestPath;
 import org.craftercms.studio.impl.v2.utils.SanitizerUtil;
 
@@ -28,6 +27,8 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.ALPHANUMERIC;
+import static org.craftercms.studio.api.v2.service.publish.PublishService.PACKAGE_COMMENT_MAX_LENGTH;
+import static org.craftercms.studio.api.v2.service.publish.PublishService.PACKAGE_TITLE_MAX_LENGTH;
 
 /**
  * Request to publish a package
@@ -43,10 +44,10 @@ public class PublishPackageRequest {
 	private boolean requestApproval;
 	private boolean publishAll;
 	@NotEmpty
-	@Size(max = 500)
+	@Size(max = PACKAGE_COMMENT_MAX_LENGTH)
 	private String comment;
 	@NotEmpty
-	@Size(max = PublishService.PACKAGE_TITLE_MAX_LENGTH)
+	@Size(max = PACKAGE_TITLE_MAX_LENGTH)
 	private String title;
 
 	public String getPublishingTarget() {

--- a/src/main/java/org/craftercms/studio/model/rest/workflow/ReviewPackageRequestBody.java
+++ b/src/main/java/org/craftercms/studio/model/rest/workflow/ReviewPackageRequestBody.java
@@ -24,13 +24,15 @@ import org.craftercms.studio.impl.v2.utils.SanitizerUtil;
 
 import java.util.List;
 
+import static org.craftercms.studio.api.v2.service.publish.PublishService.PACKAGE_COMMENT_MAX_LENGTH;
+
 /**
  * Request body for reviewing a package (reject, approve)
  */
 public class ReviewPackageRequestBody {
 
 	@NotBlank
-	@Size(max = 500)
+	@Size(max = PACKAGE_COMMENT_MAX_LENGTH)
 	private String comment;
 	@NotEmpty
 	private List<@NotNull Long> packageIds;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1181
Enforce max length for publish package comments. Cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized comment length validation across publishing and workflow operations by establishing a consistent maximum comment length constraint of 500 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->