### PR TITLE
Normalize folder paths

### DIFF
--- a/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
+++ b/src/main/java/org/craftercms/studio/controller/rest/v2/ContentController.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.commons.io.FilenameUtils.normalizeNoEndSeparator;
 import static org.craftercms.commons.validation.annotations.param.EsapiValidationType.ALPHANUMERIC;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARATOR;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.INDEX_FILE;
@@ -338,7 +339,7 @@ public class ContentController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public Result createFolder(@ValidSiteId @PathVariable String siteId, @Valid @RequestBody CreateFolderRequestBody requestBody)
 			throws UserNotFoundException, ServiceLayerException, AuthenticationException {
-		WriteContentResult createFolderResult = contentService.createFolder(siteId, requestBody.getPath());
+		WriteContentResult createFolderResult = contentService.createFolder(siteId, normalizeNoEndSeparator(requestBody.getPath()));
 		UnwrappedResult<WriteContentResult> result = UnwrappedResult.of(createFolderResult);
 		result.setResponse(CREATED);
 		return result;


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1183
Normalize folder paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced folder creation to properly normalize file paths and handle trailing separators, ensuring more consistent path behavior when creating folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->