### PR TITLE
Fix publish blacklist to be applied after updates

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/git/GitCli.java
@@ -352,7 +352,7 @@ public class GitCli {
 		executeGitCommand(readTreeCl);
 		final Path indexInfoTempFile = Files.createTempFile(getStudioTemporaryFilesRoot(), UUID.randomUUID().toString(), TMP_FILE_SUFFIX);
 		Stage prepareWriteTreeStage = taskProgress.startStage("Prepare write tree",
-			emptyIfNull(paths).size() + emptyIfNull(deletedPaths).size() + emptyIfNull(blacklistPathspecs).size());
+			emptyIfNull(paths).size() + emptyIfNull(deletedPaths).size());
 		try {
 			if (isNotEmpty(deletedPaths)) {
 				removePaths(directory, deletedPaths, prepareWriteTreeStage);
@@ -369,13 +369,17 @@ public class GitCli {
 					executeGitCommand(lsTreeCl);
 				}
 			}
-			removePaths(directory, blacklistPathspecs, prepareWriteTreeStage);
 			prepareWriteTreeStage.complete();
 			// Update index with correct version of published files
 			Stage updateIndexStage = taskProgress.startStage("Update index and write tree");
 			GitCommandLine updateIndexCl = new GitCommandLine(directory, "update-index", "--index-info");
 			updateIndexCl.setInput(indexInfoTempFile.toRealPath().toFile());
 			executeGitCommand(updateIndexCl);
+			if (isNotEmpty(blacklistPathspecs)) {
+				Stage blacklistStage = taskProgress.startStage("Apply blacklist", blacklistPathspecs.size());
+				removePaths(directory, blacklistPathspecs, blacklistStage);
+				blacklistStage.complete();
+			}
 
 			// git write-tree
 			GitCommandLine writeTreeCl = new GitCommandLine(directory, "write-tree");


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8436
Fix publish blacklist to be applied after updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reordered the write-tree workflow so removal of blacklisted paths happens in a dedicated step after the index update.
  * Preparation stage no longer counts blacklisted paths when estimating work, simplifying and clarifying the write-tree process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->