### PR TITLE
set-maintenance API to prevent conflict with public /system/maintenance GET API

### DIFF
--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -9263,6 +9263,8 @@ paths:
                     description: true if system is in maintenance mode, otherwise false
         '500':
           $ref: '#/components/responses/InternalServerError'
+
+  /api/2/system/set-maintenance:
     post:
       tags:
         - system
@@ -9280,8 +9282,8 @@ paths:
                 maintenanceMode:
                   type: boolean
                   description: true to set system in maintenance mode, false to disable maintenance mode
-                required:
-                  - maintenanceMode
+              required:
+                - maintenanceMode
       responses:
         '200':
           description: OK

--- a/src/main/api/studio-api.yaml
+++ b/src/main/api/studio-api.yaml
@@ -9264,7 +9264,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /api/2/system/set-maintenance:
+  /api/2/system/set_maintenance:
     post:
       tags:
         - system


### PR DESCRIPTION
set-maintenance API to prevent conflict with public /system/maintenance GET API
https://github.com/craftercms/craftercms/issues/5652