### PR TITLE
Tweak the populateItemParentId procedure to prevent issues with subqueries

### DIFF
--- a/src/main/resources/crafter/studio/database/createDDL.sql
+++ b/src/main/resources/crafter/studio/database/createDDL.sql
@@ -10,8 +10,7 @@ BEGIN
 		(SELECT id, max(potential_parent_path) as calculated_parent_path,
 						(SELECT p.id FROM item p WHERE (p.path = max(potential_parent_path)) and p.site_id = siteId) AS calculated_parent_id
 		FROM
-			(SELECT candidates.id, candidates.path, candidates.parent_id,
-					(SELECT p.id FROM item p WHERE (p.path = candidates.parent_path) AND p.site_id = siteId) AS potential_parent_id,
+            (SELECT candidates.id, candidates.path, candidates.parent_id, i.id as potential_parent_id,
 					candidates.parent_path as potential_parent_path
 			FROM (
 					SELECT id, parent_id, path,
@@ -23,9 +22,9 @@ BEGIN
 							concat(reverse(substr(reverse(trim('/index.xml' from path)), locate('/', reverse(trim('/index.xml' from path)))+1)), '/index.xml') AS parent_path
 					FROM item
 					WHERE site_id = siteId
-				) AS candidates
+				) AS candidates INNER JOIN item i ON candidates.parent_path = i.path AND i.site_id = siteId
+				WHERE i.site_id = siteId
 			) AS mapped
-		WHERE potential_parent_id IS NOT NULL
 		GROUP BY id
 		) AS updates
 	SET item.parent_id = updates.calculated_parent_id
@@ -225,7 +224,7 @@ CREATE TABLE _meta (
 	PRIMARY KEY (`version`)
 ) ;
 
-INSERT INTO _meta (version, studio_id) VALUES ('5.0.0.13', UUID()) ;
+INSERT INTO _meta (version, studio_id) VALUES ('5.0.0.14', UUID()) ;
 
 CREATE TABLE IF NOT EXISTS `audit` (
 	`id`                        BIGINT(20)    NOT NULL AUTO_INCREMENT,

--- a/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.13-to-5.0.0.14.sql
+++ b/src/main/resources/crafter/studio/database/upgrade/5.0.x/5.0.0.13-to-5.0.0.14.sql
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+* This update rewrites the populateItemParentId procedure to prevent
+* mariadb issues with subqueries (resolving column not found when referencing an alias from an outer query)
+*/
+DROP PROCEDURE IF EXISTS populateItemParentId ;
+
+CREATE PROCEDURE populateItemParentId(IN siteId BIGINT)
+BEGIN
+    UPDATE item,
+        (SELECT id, max(potential_parent_path) as calculated_parent_path,
+						(SELECT p.id FROM item p WHERE (p.path = max(potential_parent_path)) and p.site_id = siteId) AS calculated_parent_id
+        FROM
+            (SELECT candidates.id, candidates.path, candidates.parent_id, i.id as potential_parent_id,
+                    candidates.parent_path as potential_parent_path
+            FROM (
+					SELECT id, parent_id, path,
+							reverse(substr(reverse(trim('/index.xml' from path)), locate('/', reverse(trim('/index.xml' from path)))+1)) AS parent_path
+					FROM item
+					WHERE site_id = siteId
+				UNION
+					SELECT id, parent_id, path,
+							concat(reverse(substr(reverse(trim('/index.xml' from path)), locate('/', reverse(trim('/index.xml' from path)))+1)), '/index.xml') AS parent_path
+					FROM item
+					WHERE site_id = siteId
+				) AS candidates INNER JOIN item i ON candidates.parent_path = i.path AND i.site_id = siteId
+				WHERE i.site_id = siteId
+			) AS mapped
+        GROUP BY id
+        ) AS updates
+    SET item.parent_id = updates.calculated_parent_id
+    WHERE item.id = updates.id;
+END ;

--- a/src/main/resources/crafter/studio/upgrade/pipelines.yaml
+++ b/src/main/resources/crafter/studio/upgrade/pipelines.yaml
@@ -585,7 +585,11 @@ pipelines:
                             -   src: repo-bootstrap/global/configuration/samples/sample-ui.xml
                                 dest: configuration/samples/sample-ui.xml
                         commitDetails: Add sample file for ui.xml
-
+            -   currentVersion: 5.0.0.13
+                nextVersion: 5.0.0.14
+                operations:
+                    -   type: dbScriptUpgrader
+                        filename: upgrade/5.0.x/5.0.0.13-to-5.0.0.14.sql
 
     # Pipeline to upgrade site repositories
     site:


### PR DESCRIPTION
Tweak the populateItemParentId procedure to prevent issues with subqueries
https://github.com/craftercms/craftercms/issues/8501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parent item relationship resolution so items are reliably associated with their computed parent paths and IDs within the same site, eliminating incorrect or NULL parent mappings.
* **Chores**
  * Updated system upgrade chain and recorded product version to 5.0.0.14 to include this fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->