### PR TITLE
Prevent publish in available actions for empty folders

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/ItemDAO.java
@@ -492,6 +492,16 @@ public interface ItemDAO {
 												  @Param(PATHS) Collection<String> paths);
 
 	/**
+	 * Get the count of all the non-folder children of the given paths, recursively.
+	 *
+	 * @param siteId the site id
+	 * @param paths  the paths to get children count for
+	 * @return count of all the non-folder children of the given paths
+	 */
+	long getSubtreeItemCount(@Param(SITE_ID) String siteId,
+							 @Param(PATHS) Collection<String> paths);
+
+	/**
 	 * Get {@link ItemPathAndState} records for the given paths in a map by path
 	 *
 	 * @param siteId the site id

--- a/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/security/SemanticsAvailableActionsResolverImpl.java
@@ -22,6 +22,7 @@ import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.security.UserNotFoundException;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
+import org.craftercms.studio.api.v2.dal.ItemDAO;
 import org.craftercms.studio.api.v2.dal.ItemState;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 import org.craftercms.studio.api.v2.repository.blob.StudioBlobStore;
@@ -56,6 +57,7 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 
 	private AvailableActionsResolver availableActionsResolver;
 	private ContentService contentService;
+	private ItemDAO itemDAO;
 	private ServicesConfig servicesConfig;
 	private StudioBlobStoreResolver studioBlobStoreResolver;
 	private ContentTypeService contentTypeService;
@@ -176,6 +178,14 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 		long siteWideActions = availableActionsResolver.getSiteWideActions(siteId, username);
 		result = result | siteWideActions;
 
+		if (CONTENT_TYPE_FOLDER.equals(itemSystemType)) {
+			long childrenCount = itemDAO.getSubtreeItemCount(siteId, List.of(itemPath));
+			if (childrenCount == 0) {
+				result &= ~PUBLISH;
+				result &= ~PUBLISH_REQUEST;
+			}
+		}
+
 		return result;
 	}
 
@@ -260,5 +270,10 @@ public class SemanticsAvailableActionsResolverImpl implements SemanticsAvailable
 	@SuppressWarnings("unused")
 	public void setSecurityServiceV1(org.craftercms.studio.api.v1.service.security.SecurityService securityServiceV1) {
 		this.securityServiceV1 = securityServiceV1;
+	}
+
+	@SuppressWarnings("unused")
+	public void setItemDAO(final ItemDAO itemDAO) {
+		this.itemDAO = itemDAO;
 	}
 }

--- a/src/main/resources/crafter/studio/security/common.xml
+++ b/src/main/resources/crafter/studio/security/common.xml
@@ -279,6 +279,7 @@
 		<property name="studioBlobStoreResolver" ref="blobStoreResolver"/>
 		<property name="contentTypeService" ref="contentTypeServiceInternal"/>
 		<property name="securityServiceV1" ref="cstudioSecurityService"/>
+		<property name="itemDAO" ref="itemDao"/>
 	</bean>
 
 	<bean id="studio.loginPageFilter"

--- a/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
+++ b/src/main/resources/org/craftercms/studio/api/v2/dal/ItemDAO.xml
@@ -623,7 +623,18 @@
 		</foreach>
 	</select>
 
+	<select id="getSubtreeItemCount" resultType="java.lang.Long">
+		SELECT COUNT(*)
+		FROM (
+			<include refid="getSubtreeItemsInternalQuery" />
+		) AS subtreeItems
+	</select>
+
 	<select id="getSubtreeItemsInternal" resultMap="LightItemMap">
+		<include refid="getSubtreeItemsInternalQuery" />
+	</select>
+
+	<sql id="getSubtreeItemsInternalQuery">
 		WITH RECURSIVE children AS (
 				SELECT i.id, i.path, i.label, i.system_type, i.mime_type
 				FROM item i
@@ -645,7 +656,7 @@
 			<foreach collection="paths" item="path" index="index" open="(" separator="," close=")">
 				#{path}
 			</foreach>
-	</select>
+	</sql>
 
 	<update id="updateDeletedPageChildren">
 		UPDATE item,


### PR DESCRIPTION
Prevent publish in available actions for empty folders
https://github.com/craftercms/craftercms/issues/8406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publish and publish request actions are now suppressed for folders containing no child items, preventing unintended publication of empty folder structures.

* **Improvements**
  * More accurate detection of empty folder contents to reliably control available publish actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->