### PR TITLE
Honor content type paths restriction on write-content APIs

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/service/content/ContentTypeService.java
+++ b/src/main/java/org/craftercms/studio/api/v2/service/content/ContentTypeService.java
@@ -139,4 +139,15 @@ public interface ContentTypeService {
 	 * @return a collection of the ids of the content types allowed for the given site and path
 	 */
 	Collection<String> getAllowedContentTypes(String siteId, String path) throws ServiceLayerException;
+
+	/**
+	 * Checks if a given content type is allowed for the given site and path
+	 *
+	 * @param siteId        the id of the site
+	 * @param path          the path of the content item to be created
+	 * @param contentTypeId the id of the content type to check
+	 * @return true if the content type is allowed for the given site and path, false otherwise
+	 * @throws ServiceLayerException if there is any error checking if the content type is allowed
+	 */
+	boolean isContentTypeAllowed(String siteId, String path, String contentTypeId) throws ServiceLayerException;
 }

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentTypeServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/ContentTypeServiceImpl.java
@@ -140,6 +140,13 @@ public class ContentTypeServiceImpl implements ContentTypeService {
 	}
 
 	@Override
+	@RequireSiteReady
+	@HasPermission(type = DefaultPermission.class, action = PERMISSION_CONTENT_READ)
+	public boolean isContentTypeAllowed(@SiteId String siteId, @ContentPath String path, String contentTypeId) throws ServiceLayerException {
+		return contentTypeServiceInternal.isContentTypeAllowed(siteId, path, contentTypeId);
+	}
+
+	@Override
 	@HasPermission(type = DefaultPermission.class, action = PERMISSION_READ_CONFIGURATION)
 	public String getContentTypeControllerPath(String contentTypeId) {
 		return contentTypeServiceInternal.getContentTypeControllerPath(contentTypeId);

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -517,6 +517,9 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 					throw new InvalidParametersException("Content is not a valid XML document");
 				}
 				String contentType = document.getRootElement().valueOf(CONTENT_TYPE);
+				if (!contentTypeService.isContentTypeAllowed(siteId, path, contentType)) {
+					throw new InvalidParametersException(format("Content type '%s' is not allowed at site '%s' for path '%s'", contentType, siteId, path));
+				}
 				if (isPageDescriptor(path)) {
 					pageNavOrderService.updateNavOrder(siteId, path, document);
 				}
@@ -1245,7 +1248,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 * @throws InvalidParametersException if any of the validations fail
 	 */
 	protected void validateCopyOperation(String siteId, String sourcePath, String targetPath, Set<String> childPaths)
-			throws ContentNotFoundException, InvalidParametersException {
+			throws ServiceLayerException, UserNotFoundException {
 		validateMoveOrCopyOperation(siteId, sourcePath, targetPath);
 		for (String childPath : childPaths) {
 			if (!equalsNormalized(sourcePath, childPath) && !directoryContains(sourcePath, childPath)) {
@@ -1269,7 +1272,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 * @throws ContentNotFoundException   if the parent path of the target does not exist
 	 */
 	protected void validateMoveOrCopyOperation(String siteId, String sourcePath, String targetPath)
-			throws InvalidParametersException, ContentNotFoundException {
+			throws ServiceLayerException, UserNotFoundException {
 		if (!CS.equals(getExtension(sourcePath), getExtension(targetPath))) {
 			throw new InvalidParametersException(format("Cannot copy or move content from '%s' to '%s': " +
 					"source and target paths must have the same extension", sourcePath, targetPath));
@@ -1288,6 +1291,12 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 							"from '%s' (%s) into '%s' (%s) for site '%s'. " +
 							"Pasting across top level folders is not supported.",
 					sourcePath, sourceTopLevel, targetPath, targetTopLevel, siteId));
+		}
+
+		ContentItem sourceItem = getItemByPath(siteId, sourcePath, true);
+		if (isNotEmpty(sourceItem.getContentTypeId()) && !contentTypeService.isContentTypeAllowed(siteId, targetPath, sourceItem.getContentTypeId())) {
+			throw new InvalidParametersException(format("Cannot copy or move content from '%s' to '%s': " +
+					"content type '%s' of the source item is not allowed in the target location", sourcePath, targetPath, sourceItem.getContentTypeId()));
 		}
 	}
 
@@ -1919,7 +1928,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 	 * @throws InvalidParametersException if any of the validation checks fail
 	 */
 	protected void validateMoveOperation(String siteId, String sourcePath, String targetPath)
-			throws ServiceLayerException {
+			throws ServiceLayerException, UserNotFoundException {
 		validateMoveOrCopyOperation(siteId, sourcePath, targetPath);
 		if (directoryContains(sourcePath, targetPath)) {
 			throw new InvalidParametersException(format("Cannot move content from '%s' to a directory of itself: '%s' in site '%s': " +

--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentTypeServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentTypeServiceInternalImpl.java
@@ -248,6 +248,12 @@ public class ContentTypeServiceInternalImpl implements org.craftercms.studio.api
 	}
 
 	@Override
+	public boolean isContentTypeAllowed(String siteId, String path, String contentTypeId) throws ServiceLayerException {
+		Collection<String> allowedContentTypes = getAllowedContentTypes(siteId, path);
+		return allowedContentTypes.contains(contentTypeId);
+	}
+
+	@Override
 	public ContentTypeUsage getContentTypeUsage(String siteId, String contentType) throws ServiceLayerException {
 
 		var usages = new ContentTypeUsage();


### PR DESCRIPTION
Honor content type paths restriction on write-content APIs
https://github.com/craftercms/craftercms/issues/6671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content type placement rules are now enforced during lifecycle operations and move/copy actions
  * The system validates that content types are permitted for specific site locations before allowing operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->