### PR TITLE
Allow content edit regardless of content type path rules

### DIFF
--- a/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/content/internal/ContentServiceInternalImpl.java
@@ -524,7 +524,7 @@ public class ContentServiceInternalImpl implements ContentService, ApplicationEv
 					throw new InvalidParametersException("Content is not a valid XML document");
 				}
 				String contentType = document.getRootElement().valueOf(CONTENT_TYPE);
-				if (!contentTypeService.isContentTypeAllowed(siteId, path, contentType)) {
+				if (NEW.equals(operation) && !contentTypeService.isContentTypeAllowed(siteId, path, contentType)) {
 					throw new InvalidParametersException(format("Content type '%s' is not allowed at site '%s' for path '%s'", contentType, siteId, path));
 				}
 				if (isPageDescriptor(path)) {


### PR DESCRIPTION
Related to https://github.com/craftercms/craftercms/issues/8672
Allow content edit regardless of content type path rules