### PR TITLE
Rename action types for consistency

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v2/dal/AuditLogConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/AuditLogConstants.java
@@ -38,15 +38,14 @@ public abstract class AuditLogConstants {
 	public static final String OPERATION_PUSH_TO_REMOTE = "PUSH_TO_REMOTE";
 	public static final String OPERATION_PULL_FROM_REMOTE = "PULL_FROM_REMOTE";
 	public static final String OPERATION_REQUEST_PUBLISH = "REQUEST_PUBLISH";
-	public static final String OPERATION_APPROVE = "APPROVE";
 	public static final String OPERATION_APPROVE_SCHEDULED = "APPROVE_SCHEDULED";
-	public static final String OPERATION_REJECT = "REJECT";
 	public static final String OPERATION_PUBLISHED = "PUBLISHED";
 	public static final String OPERATION_REVERT = "REVERT";
 	public static final String OPERATION_ENABLE = "ENABLE";
 	public static final String OPERATION_DISABLE = "DISABLE";
 	public static final String OPERATION_START_PUBLISHER = "START_PUBLISHER";
 	public static final String OPERATION_STOP_PUBLISHER = "STOP_PUBLISHER";
+	public static final String OPERATION_APPROVE_PUBLISH_PACKAGE = "APPROVE_PUBLISH_PACKAGE";
 	public static final String OPERATION_CANCEL_PUBLISH_PACKAGE = "CANCEL_PUBLISH_PACKAGE";
 	public static final String OPERATION_REJECT_PUBLISH_PACKAGE = "REJECT_PUBLISH_PACKAGE";
 	public static final String OPERATION_PUBLISH = "PUBLISH";

--- a/src/main/java/org/craftercms/studio/api/v2/dal/AuditLogConstants.java
+++ b/src/main/java/org/craftercms/studio/api/v2/dal/AuditLogConstants.java
@@ -39,7 +39,7 @@ public abstract class AuditLogConstants {
 	public static final String OPERATION_PULL_FROM_REMOTE = "PULL_FROM_REMOTE";
 	public static final String OPERATION_REQUEST_PUBLISH = "REQUEST_PUBLISH";
 	public static final String OPERATION_APPROVE_SCHEDULED = "APPROVE_SCHEDULED";
-	public static final String OPERATION_PUBLISHED = "PUBLISHED";
+	public static final String OPERATION_ITEM_LIST_PUBLISHED = "PUBLISH_ITEM_LIST_COMPLETE";
 	public static final String OPERATION_REVERT = "REVERT";
 	public static final String OPERATION_ENABLE = "ENABLE";
 	public static final String OPERATION_DISABLE = "DISABLE";
@@ -49,10 +49,10 @@ public abstract class AuditLogConstants {
 	public static final String OPERATION_CANCEL_PUBLISH_PACKAGE = "CANCEL_PUBLISH_PACKAGE";
 	public static final String OPERATION_REJECT_PUBLISH_PACKAGE = "REJECT_PUBLISH_PACKAGE";
 	public static final String OPERATION_PUBLISH = "PUBLISH";
-	public static final String OPERATION_INITIAL_PUBLISH = "INITIAL_PUBLISH";
+	public static final String OPERATION_INITIAL_PUBLISH = "INITIAL_PUBLISH_COMPLETE";
 	public static final String OPERATION_SYSTEM_PROPERTY_UPDATE = "SYSTEM_PROPERTY_UPDATE";
 	public static final String OPERATION_PUBLISH_START = "PUBLISH_START";
-	public static final String OPERATION_PUBLISH_ALL = "PUBLISH_ALL";
+	public static final String OPERATION_PUBLISH_ALL = "PUBLISH_ALL_COMPLETE";
 	public static final String OPERATION_GIT_CHANGES = "GIT_SYNC";
 	public static final String OPERATION_UNKNOWN = "UNKNOWN";
 

--- a/src/main/java/org/craftercms/studio/impl/v2/publish/Publisher.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/publish/Publisher.java
@@ -16,7 +16,21 @@
 
 package org.craftercms.studio.impl.v2.publish;
 
+import java.beans.ConstructorProperties;
+import java.io.IOException;
+import static java.lang.String.format;
+import static java.time.Instant.now;
+import java.util.ArrayList;
+import java.util.Collection;
+import static java.util.Collections.emptyList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.collections4.ListUtils;
+import static org.apache.commons.lang3.Strings.CS;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -26,12 +40,22 @@ import org.craftercms.studio.api.v1.service.GeneralLockService;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.annotation.LogExecutionTime;
 import org.craftercms.studio.api.v2.dal.AuditLog;
+import static org.craftercms.studio.api.v2.dal.AuditLog.createAuditLogEntry;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_INITIAL_PUBLISH;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_ITEM_LIST_PUBLISHED;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_PUBLISH_ALL;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_PUBLISH_START;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.TARGET_TYPE_PUBLISH_PACKAGE;
 import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.dal.SiteDAO;
 import org.craftercms.studio.api.v2.dal.publish.ItemTargetDAO;
 import org.craftercms.studio.api.v2.dal.publish.PublishDAO;
 import org.craftercms.studio.api.v2.dal.publish.PublishItem;
+import static org.craftercms.studio.api.v2.dal.publish.PublishItem.Action.DELETE;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.COMPLETED;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.PROCESSING;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.READY;
 import org.craftercms.studio.api.v2.event.publish.PublishErrorEvent;
 import org.craftercms.studio.api.v2.event.publish.PublishEvent;
 import org.craftercms.studio.api.v2.event.publish.RequestPublishEvent;
@@ -56,23 +80,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.event.EventListener;
+import static org.springframework.data.util.Predicates.negate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.PlatformTransactionManager;
-
-import java.beans.ConstructorProperties;
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.lang.String.format;
-import static java.time.Instant.now;
-import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.Strings.CS;
-import static org.craftercms.studio.api.v2.dal.AuditLog.createAuditLogEntry;
-import static org.craftercms.studio.api.v2.dal.AuditLogConstants.*;
-import static org.craftercms.studio.api.v2.dal.publish.PublishItem.Action.DELETE;
-import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.*;
-import static org.springframework.data.util.Predicates.negate;
 
 /**
  * Listen for {@link RequestPublishEvent} and handle accordingly.
@@ -201,7 +211,7 @@ public class Publisher implements ApplicationEventPublisherAware {
 				}
 				case ITEM_LIST -> {
 					logger.debug("Processing publish package '{}' for site '{}'", packageId, siteId);
-					activityOperation = OPERATION_PUBLISHED;
+					activityOperation = OPERATION_ITEM_LIST_PUBLISHED;
 					doPublishItemList(publishPackage, publishItems, this::doPublishItemListTarget);
 				}
 				default -> throw new ServiceLayerException(format("Unknown package type '%s' for package '%d' for site '%s'",
@@ -209,8 +219,8 @@ public class Publisher implements ApplicationEventPublisherAware {
 			}
 		} finally {
 			Stage completeStage = taskProgress.startStage("Save completed package");
-			auditPublishOperation(publishPackage, OPERATION_PUBLISHED);
 			if (activityOperation != null) {
+				auditPublishOperation(publishPackage, activityOperation);
 				activityService.insertActivity(publishPackage.getSiteId(), publishPackage.getSubmitterId(), activityOperation, DateUtils.getCurrentTime(),
 					null, Long.toString(packageId));
 			}

--- a/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/service/workflow/internal/WorkflowServiceInternalImpl.java
@@ -16,18 +16,32 @@
 
 package org.craftercms.studio.impl.v2.service.workflow.internal;
 
+import java.time.Instant;
+import static java.time.Instant.now;
+import java.util.Collection;
+import java.util.List;
+
 import org.craftercms.studio.api.v1.exception.ServiceLayerException;
 import org.craftercms.studio.api.v1.exception.SiteNotFoundException;
 import org.craftercms.studio.api.v1.exception.security.AuthenticationException;
 import org.craftercms.studio.api.v1.service.GeneralLockService;
 import org.craftercms.studio.api.v1.service.configuration.ServicesConfig;
 import org.craftercms.studio.api.v2.dal.AuditLog;
+import static org.craftercms.studio.api.v2.dal.AuditLog.createAuditLogEntry;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_APPROVE_PUBLISH_PACKAGE;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_CANCEL_PUBLISH_PACKAGE;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.OPERATION_REJECT_PUBLISH_PACKAGE;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.ORIGIN_API;
+import static org.craftercms.studio.api.v2.dal.AuditLogConstants.TARGET_TYPE_PUBLISH_PACKAGE;
 import org.craftercms.studio.api.v2.dal.RetryingDatabaseOperationFacade;
 import org.craftercms.studio.api.v2.dal.Site;
 import org.craftercms.studio.api.v2.dal.User;
 import org.craftercms.studio.api.v2.dal.item.ContentItem;
 import org.craftercms.studio.api.v2.dal.publish.PublishDAO;
 import org.craftercms.studio.api.v2.dal.publish.PublishPackage;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.APPROVED;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.REJECTED;
+import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.CANCELLED;
 import org.craftercms.studio.api.v2.event.workflow.WorkflowEvent;
 import org.craftercms.studio.api.v2.exception.publish.InvalidPackageStateException;
 import org.craftercms.studio.api.v2.exception.publish.PackageAlreadyApprovedException;
@@ -37,27 +51,16 @@ import org.craftercms.studio.api.v2.service.audit.AuditService;
 import org.craftercms.studio.api.v2.service.item.ItemService;
 import org.craftercms.studio.api.v2.service.site.SitesService;
 import org.craftercms.studio.api.v2.service.workflow.WorkflowService;
+import static org.craftercms.studio.api.v2.utils.StudioUtils.getPublishPackageLockKey;
+import static org.craftercms.studio.api.v2.utils.StudioUtils.getSandboxRepoLockKey;
 import org.craftercms.studio.impl.v2.utils.DateUtils;
+import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getAuthentication;
+import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUser;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-
-import java.time.Instant;
-import java.util.Collection;
-import java.util.List;
-
-import static java.time.Instant.now;
-import static org.craftercms.studio.api.v2.dal.AuditLog.createAuditLogEntry;
-import static org.craftercms.studio.api.v2.dal.AuditLogConstants.*;
-import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.APPROVED;
-import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.ApprovalState.REJECTED;
-import static org.craftercms.studio.api.v2.dal.publish.PublishPackage.PackageState.CANCELLED;
-import static org.craftercms.studio.api.v2.utils.StudioUtils.getPublishPackageLockKey;
-import static org.craftercms.studio.api.v2.utils.StudioUtils.getSandboxRepoLockKey;
-import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getAuthentication;
-import static org.craftercms.studio.impl.v2.utils.security.SecurityUtils.getCurrentUser;
 
 public class WorkflowServiceInternalImpl implements WorkflowService, ApplicationEventPublisherAware {
 
@@ -108,7 +111,7 @@ public class WorkflowServiceInternalImpl implements WorkflowService, Application
 				}
 				p.setApprovalState(APPROVED);
 				p.setReviewerComment(comment);
-			}, OPERATION_APPROVE, WorkflowEvent.WorkFlowEventType.APPROVE);
+			}, OPERATION_APPROVE_PUBLISH_PACKAGE, WorkflowEvent.WorkFlowEventType.APPROVE);
 		}
 	}
 


### PR DESCRIPTION
Rename action types for consistency
Fix activity on publish complete
https://github.com/craftercms/craftercms/issues/8770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Audit Logging**
  * Approval actions for publish packages are now recorded with a dedicated audit operation.
  * Publishing audit entries now use the operation that matches the specific package/publish type (including item-list publish).

* **API/Operation Constants**
  * Legacy generic approve/reject and published operation labels were removed.
  * New/updated publish-related operation constants were introduced, and key operation values were renamed to reflect “complete” states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->