### PR TITLE
Use per-site classloaders for lifecycle Groovy scripts

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/script/ScriptExecutor.java
+++ b/src/main/java/org/craftercms/studio/api/v1/script/ScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -21,5 +21,12 @@ import java.util.Map;
 
 public interface ScriptExecutor {
 
-    void executeScriptString(String script, Map<String, Object> model) throws ScriptException;
+    /**
+     * Execute a Groovy script string using the script engine for the given site
+     *
+     * @param siteId the site id
+     * @param script the script to execute
+     * @param model  bindings available to the script
+     */
+    void executeScriptString(String siteId, String script, Map<String, Object> model) throws ScriptException;
 }

--- a/src/main/java/org/craftercms/studio/api/v2/scripting/ScriptEngineManager.java
+++ b/src/main/java/org/craftercms/studio/api/v2/scripting/ScriptEngineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -33,7 +33,7 @@ public interface ScriptEngineManager {
     GroovyScriptEngine getScriptEngine(String siteId);
 
     /**
-     * Creates a new {@link GroovyScriptEngine} for the given site
+     * Creates a new {@link GroovyScriptEngine} for the given site, closing the previous one if present
      * @param siteId the id of the site
      */
     void reloadScriptEngine(String siteId);

--- a/src/main/java/org/craftercms/studio/impl/v1/script/GroovyScriptExecutor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/script/GroovyScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,63 +16,107 @@
 
 package org.craftercms.studio.impl.v1.script;
 
-import groovy.lang.GroovyClassLoader;
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
-import org.craftercms.studio.api.v1.script.ScriptExecutor;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor;
-import org.kohsuke.groovy.sandbox.SandboxTransformer;
+import java.beans.ConstructorProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
-import java.beans.ConstructorProperties;
-import java.util.List;
-import java.util.Map;
 
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
+import org.craftercms.studio.api.v1.script.ScriptExecutor;
+import org.craftercms.studio.api.v2.event.site.SiteDeletingEvent;
+import org.craftercms.studio.impl.v2.utils.GroovyClassLoaderUtils;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor;
+import org.kohsuke.groovy.sandbox.SandboxTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+import groovy.lang.GroovyClassLoader;
+
+/**
+ * Executes content-lifecycle Groovy scripts with a shared parent classloader for configured
+ * classpath entries and a closable per-site child classloader for compiled scripts.
+ */
 public class GroovyScriptExecutor implements ScriptExecutor {
 
-	protected final static String GROOVY_ENGINE_NAME = "groovy";
+	private static final Logger logger = LoggerFactory.getLogger(GroovyScriptExecutor.class);
+
+	protected static final String GROOVY_ENGINE_NAME = "groovy";
 	protected final SandboxInterceptor sandboxInterceptor;
 	protected final boolean enableScriptSandbox;
 	protected final List<String> scriptsClassPath;
-	protected GroovyScriptEngineImpl scriptEngine;
+
+	protected CompilerConfiguration compilerConfig;
+	protected GroovyClassLoader sharedClassLoader;
+	protected ScriptEngineManager scriptEngineFactory;
+	protected final Map<String, GroovyScriptEngineImpl> scriptEngines = new ConcurrentHashMap<>();
 
 	@ConstructorProperties({"sandboxInterceptor", "scriptsClassPath", "enableScriptSandbox"})
-	public GroovyScriptExecutor(SandboxInterceptor sandboxInterceptor, List<String> scriptsClassPath, boolean enableScriptSandbox) {
+	public GroovyScriptExecutor(SandboxInterceptor sandboxInterceptor, List<String> scriptsClassPath,
+								boolean enableScriptSandbox) {
 		this.sandboxInterceptor = sandboxInterceptor;
 		this.scriptsClassPath = scriptsClassPath;
 		this.enableScriptSandbox = enableScriptSandbox;
 	}
 
 	protected void init() {
-		ScriptEngineManager factory = new ScriptEngineManager();
-		this.scriptEngine = (GroovyScriptEngineImpl) factory.getEngineByName(GROOVY_ENGINE_NAME);
-		CompilerConfiguration config = new CompilerConfiguration();
+		compilerConfig = new CompilerConfiguration();
 		if (enableScriptSandbox) {
-			config.addCompilationCustomizers(new RejectASTTransformsCustomizer(), new SandboxTransformer());
+			compilerConfig.addCompilationCustomizers(new RejectASTTransformsCustomizer(), new SandboxTransformer());
 		}
-		scriptEngine.setClassLoader(new GroovyClassLoader(scriptEngine.getClassLoader(), config));
+		sharedClassLoader = new GroovyClassLoader(getClass().getClassLoader(), compilerConfig);
 		for (String classPath : scriptsClassPath) {
-			scriptEngine.getClassLoader().addClasspath(classPath);
+			sharedClassLoader.addClasspath(classPath);
 		}
+		scriptEngineFactory = new ScriptEngineManager();
 	}
 
 	@Override
-	public void executeScriptString(String script, Map<String, Object> model) throws ScriptException {
-		if (scriptEngine == null) {
+	public void executeScriptString(String siteId, String script, Map<String, Object> model) throws ScriptException {
+		if (sharedClassLoader == null) {
 			throw new IllegalStateException("GroovyScriptExecutor not initialized (init() not called)");
 		}
 		if (enableScriptSandbox && sandboxInterceptor != null) {
 			sandboxInterceptor.register();
 		}
 		try {
-			this.scriptEngine.eval(script, new SimpleBindings(model));
+			getScriptEngine(siteId).eval(script, new SimpleBindings(model));
 		} finally {
 			if (enableScriptSandbox && sandboxInterceptor != null) {
 				sandboxInterceptor.unregister();
 			}
+		}
+	}
+
+	protected GroovyScriptEngineImpl getScriptEngine(String siteId) {
+		return scriptEngines.computeIfAbsent(siteId, this::createScriptEngine);
+	}
+
+	protected GroovyScriptEngineImpl createScriptEngine(String siteId) {
+		logger.debug("Create a lifecycle Script Engine for site '{}'", siteId);
+		GroovyScriptEngineImpl scriptEngine = (GroovyScriptEngineImpl) scriptEngineFactory.getEngineByName(GROOVY_ENGINE_NAME);
+		GroovyClassLoader siteClassLoader = new GroovyClassLoader(sharedClassLoader, compilerConfig);
+		scriptEngine.setClassLoader(siteClassLoader);
+		return scriptEngine;
+	}
+
+	@EventListener
+	public void onSiteDeleting(SiteDeletingEvent event) {
+		removeScriptEngine(event.getSiteId());
+	}
+
+	protected void removeScriptEngine(String siteId) {
+		logger.debug("Remove the lifecycle Script Engine for site '{}'", siteId);
+		GroovyScriptEngineImpl removed = scriptEngines.remove(siteId);
+		if (removed != null) {
+			// Close the site child only; keep the shared parent classpath loader
+			GroovyClassLoaderUtils.closeQuietly(removed.getClassLoader(), sharedClassLoader);
 		}
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v1/service/content/DmContentLifeCycleServiceImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/service/content/DmContentLifeCycleServiceImpl.java
@@ -100,7 +100,7 @@ public class DmContentLifeCycleServiceImpl implements DmContentLifeCycleService,
         if (StringUtils.isNotEmpty(script)) {
             Map<String, Object> model = buildModel(site, user, path, contentType, operation.toString(), params);
             try {
-                scriptExecutor.executeScriptString(script, model);
+                scriptExecutor.executeScriptString(site, script, model);
             } catch (Exception e) {
                 logger.error("Failed to execute content lifecycle script in site '{}' path '{}'", site, path, e);
             }

--- a/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
@@ -15,11 +15,15 @@
  */
 package org.craftercms.studio.impl.v2.scripting;
 
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyResourceLoader;
-import groovy.util.GroovyScriptEngine;
-import groovy.util.ResourceConnector;
-import groovy.util.ResourceException;
+import java.beans.ConstructorProperties;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.craftercms.core.service.ContentStoreService;
 import org.craftercms.engine.util.url.ContentStoreUrlConnection;
@@ -33,14 +37,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
 
-import java.beans.ConstructorProperties;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLStreamHandler;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyResourceLoader;
+import groovy.util.GroovyScriptEngine;
+import groovy.util.ResourceConnector;
+import groovy.util.ResourceException;
 
 /**
  * Default implementation of {@link ScriptEngineManager}
@@ -102,10 +103,11 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
     public void reloadScriptEngine(String siteId) {
         logger.debug("Reload the Script Engine for site '{}'", siteId);
         scriptEngines.compute(siteId, (key, old) -> {
+            GroovyScriptEngine fresh = createScriptEngine(siteId);
             if (old != null) {
                 GroovyClassLoaderUtils.closeQuietly(old.getGroovyClassLoader());
             }
-            return createScriptEngine(siteId);
+            return fresh;
         });
     }
 

--- a/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -24,11 +24,14 @@ import org.codehaus.groovy.control.CompilerConfiguration;
 import org.craftercms.core.service.ContentStoreService;
 import org.craftercms.engine.util.url.ContentStoreUrlConnection;
 import org.craftercms.studio.api.v2.core.ContextManager;
+import org.craftercms.studio.api.v2.event.site.SiteDeletingEvent;
 import org.craftercms.studio.api.v2.scripting.ScriptEngineManager;
+import org.craftercms.studio.impl.v2.utils.GroovyClassLoaderUtils;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
 import org.kohsuke.groovy.sandbox.SandboxTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
 
 import java.beans.ConstructorProperties;
 import java.io.File;
@@ -38,8 +41,6 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static org.craftercms.studio.api.v2.utils.StudioUtils.getSiteId;
 
 /**
  * Default implementation of {@link ScriptEngineManager}
@@ -100,7 +101,21 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
     @Override
     public void reloadScriptEngine(String siteId) {
         logger.debug("Reload the Script Engine for site '{}'", siteId);
-        scriptEngines.compute(siteId, (key, old) -> createScriptEngine(siteId));
+        scriptEngines.compute(siteId, (key, old) -> {
+            if (old != null) {
+                GroovyClassLoaderUtils.closeQuietly(old.getGroovyClassLoader());
+            }
+            return createScriptEngine(siteId);
+        });
+    }
+
+    @EventListener
+    public void onSiteDeleting(SiteDeletingEvent event) {
+        logger.debug("Remove the Script Engine for site '{}'", event.getSiteId());
+        GroovyScriptEngine removed = scriptEngines.remove(event.getSiteId());
+        if (removed != null) {
+            GroovyClassLoaderUtils.closeQuietly(removed.getGroovyClassLoader());
+        }
     }
 
     // Internal classes used to load the scripts from the site

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.impl.v2.utils;
+
+import groovy.lang.GroovyClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helpers for releasing {@link GroovyClassLoader} resources.
+ */
+public abstract class GroovyClassLoaderUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(GroovyClassLoaderUtils.class);
+
+	/**
+	 * Clear and close this classloader and any {@link GroovyClassLoader} parents.
+	 *
+	 * @param classLoader the classloader to close (may be null)
+	 */
+	public static void closeQuietly(ClassLoader classLoader) {
+		closeQuietly(classLoader, null);
+	}
+
+	/**
+	 * Clear and close this classloader and {@link GroovyClassLoader} parents, stopping before {@code stopAt}.
+	 *
+	 * @param classLoader the classloader to close (may be null)
+	 * @param stopAt      parent to leave open; closing stops when this loader is reached (exclusive).
+	 *                    If null, stops at the first non-{@link GroovyClassLoader} parent.
+	 */
+	public static void closeQuietly(ClassLoader classLoader, ClassLoader stopAt) {
+		while (classLoader instanceof GroovyClassLoader groovyClassLoader) {
+			if (classLoader == stopAt) {
+				break;
+			}
+			try {
+				groovyClassLoader.clearCache();
+				groovyClassLoader.close();
+			} catch (Exception e) {
+				logger.warn("Failed to close Groovy class loader", e);
+			}
+			classLoader = classLoader.getParent();
+		}
+	}
+
+}

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
@@ -15,9 +15,10 @@
  */
 package org.craftercms.studio.impl.v2.utils;
 
-import groovy.lang.GroovyClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import groovy.lang.GroovyClassLoader;
 
 /**
  * Helpers for releasing {@link GroovyClassLoader} resources.
@@ -48,7 +49,6 @@ public abstract class GroovyClassLoaderUtils {
 				break;
 			}
 			try {
-				groovyClassLoader.clearCache();
 				groovyClassLoader.close();
 			} catch (Exception e) {
 				logger.warn("Failed to close Groovy class loader", e);


### PR DESCRIPTION
Keep shared classpath on a parent loader and close each site's child loader on delete. Extract GroovyClassLoaderUtils for reuse with ScriptEngineManagerImpl.
https://github.com/craftersoftware/craftercms/issues/1266