### PR TITLE
Use per-site classloaders for lifecycle Groovy scripts

### DIFF
--- a/src/main/java/org/craftercms/studio/api/v1/script/ScriptExecutor.java
+++ b/src/main/java/org/craftercms/studio/api/v1/script/ScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2024 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -13,13 +13,20 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package org.craftercms.studio.api.v1.script;
 
-import javax.script.ScriptException;
 import java.util.Map;
+
+import javax.script.ScriptException;
 
 public interface ScriptExecutor {
 
+	/**
+	 * Execute a Groovy script string using the script engine for the given site
+	 *
+	 * @param siteId the site id
+	 * @param script the script to execute
+	 * @param model bindings available to the script
+	 */
 	void executeScriptString(String siteId, String script, Map<String, Object> model) throws ScriptException;
 }

--- a/src/main/java/org/craftercms/studio/api/v2/scripting/ScriptEngineManager.java
+++ b/src/main/java/org/craftercms/studio/api/v2/scripting/ScriptEngineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -26,7 +26,8 @@ import groovy.util.GroovyScriptEngine;
 public interface ScriptEngineManager {
 
 	/**
-	 * Returns the {@link GroovyScriptEngine} for the given site, if it doesn't exist then a new one is created
+	 * Returns the {@link GroovyScriptEngine} for the given site, if it doesn't
+	 * exist then a new one is created
 	 *
 	 * @param siteId the id fo the site
 	 * @return the script engine instance
@@ -34,7 +35,9 @@ public interface ScriptEngineManager {
 	GroovyScriptEngine getScriptEngine(String siteId);
 
 	/**
-	 * Creates a new {@link GroovyScriptEngine} for the given site
+	 * Creates a new {@link GroovyScriptEngine} for the given site, closing the
+	 * previous one if present
+	 *
 	 *
 	 * @param siteId the id of the site
 	 */

--- a/src/main/java/org/craftercms/studio/impl/v1/script/GroovyScriptExecutor.java
+++ b/src/main/java/org/craftercms/studio/impl/v1/script/GroovyScriptExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,37 +16,50 @@
 
 package org.craftercms.studio.impl.v1.script;
 
-import groovy.lang.GroovyClassLoader;
-import org.apache.commons.lang3.StringUtils;
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
-import org.craftercms.studio.api.v1.script.ScriptExecutor;
-import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor;
-import org.kohsuke.groovy.sandbox.SandboxTransformer;
+import java.beans.ConstructorProperties;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import javax.script.SimpleBindings;
-import java.beans.ConstructorProperties;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.jsr223.GroovyScriptEngineImpl;
 import static org.craftercms.studio.api.v1.constant.GitRepositories.SANDBOX;
 import static org.craftercms.studio.api.v1.constant.StudioConstants.FILE_SEPARATOR;
+import org.craftercms.studio.api.v1.script.ScriptExecutor;
+import org.craftercms.studio.api.v2.event.site.SiteDeletingEvent;
+import org.craftercms.studio.api.v2.utils.GitRepositoryHelper;
+import org.craftercms.studio.impl.v2.utils.GroovyClassLoaderUtils;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor;
+import org.kohsuke.groovy.sandbox.SandboxTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+import groovy.lang.GroovyClassLoader;
 
 public class GroovyScriptExecutor implements ScriptExecutor {
 
 	protected final static String GROOVY_ENGINE_NAME = "groovy";
+	private static final Logger logger = LoggerFactory.getLogger(GroovyScriptExecutor.class);
 
 	protected GitRepositoryHelper gitRepositoryHelper;
 	protected final SandboxInterceptor sandboxInterceptor;
 	protected final boolean enableScriptSandbox;
 	protected final List<String> scriptsClassPath;
 	protected String pluginClassPath;
+
+	protected CompilerConfiguration compilerConfig;
+	protected GroovyClassLoader sharedClassLoader;
+	protected ScriptEngineManager scriptEngineFactory;
+	protected final Map<String, GroovyScriptEngineImpl> scriptEngines = new ConcurrentHashMap<>();
 
 	@ConstructorProperties({"gitRepositoryHelper", "sandboxInterceptor", "scriptsClassPath", "pluginClassPath", "enableScriptSandbox"})
 	public GroovyScriptExecutor(final GitRepositoryHelper gitRepositoryHelper, SandboxInterceptor sandboxInterceptor,
@@ -56,37 +69,59 @@ public class GroovyScriptExecutor implements ScriptExecutor {
 		this.scriptsClassPath = scriptsClassPath;
 		this.pluginClassPath = pluginClassPath;
 		this.enableScriptSandbox = enableScriptSandbox;
-	}
 
-	protected ScriptEngine getScriptEngine(String siteId, Map<String, Object> model) {
-		ScriptEngineManager factory = new ScriptEngineManager();
-		factory.setBindings(new SimpleBindings(model));
-		GroovyScriptEngineImpl scriptEngine = (GroovyScriptEngineImpl) factory.getEngineByName(GROOVY_ENGINE_NAME);
-		CompilerConfiguration config = new CompilerConfiguration();
+		compilerConfig = new CompilerConfiguration();
 		if (enableScriptSandbox) {
-			config.addCompilationCustomizers(new RejectASTTransformsCustomizer(), new SandboxTransformer());
+			compilerConfig.addCompilationCustomizers(new RejectASTTransformsCustomizer(), new SandboxTransformer());
 		}
-		scriptEngine.setClassLoader(new GroovyClassLoader(scriptEngine.getClassLoader(), config));
+		sharedClassLoader = new GroovyClassLoader(getClass().getClassLoader(), compilerConfig);
+		scriptEngineFactory = new ScriptEngineManager();
 		for (String classPath : scriptsClassPath) {
-			scriptEngine.getClassLoader().addClasspath(classPath);
+			sharedClassLoader.addClasspath(classPath);
 		}
-
-		scriptEngine.getClassLoader().addClasspath(getPluginClassFullPath(siteId));
-		return scriptEngine;
 	}
 
 	@Override
 	public void executeScriptString(String siteId, String script, Map<String, Object> model) throws ScriptException {
+		if(sharedClassLoader == null) {
+			throw new IllegalStateException("GroovyScriptExecutor not initialized, call init() method first");
+		}
 		if (enableScriptSandbox && sandboxInterceptor != null) {
 			sandboxInterceptor.register();
 		}
 		try {
-			ScriptEngine scriptEngine = getScriptEngine(siteId, model);
-			scriptEngine.eval(script);
+			getScriptEngine(siteId).eval(script, new SimpleBindings(model));
 		} finally {
 			if (enableScriptSandbox && sandboxInterceptor != null) {
 				sandboxInterceptor.unregister();
 			}
+		}
+	}
+
+	protected GroovyScriptEngineImpl getScriptEngine(String siteId) {
+		return scriptEngines.computeIfAbsent(siteId, this::createScriptEngine);
+	}
+
+	protected GroovyScriptEngineImpl createScriptEngine(String siteId) {
+		logger.debug("Create a lifecycle Script Engine for site '{}'", siteId);
+		GroovyScriptEngineImpl scriptEngine = (GroovyScriptEngineImpl) scriptEngineFactory.getEngineByName(GROOVY_ENGINE_NAME);
+		GroovyClassLoader siteClassLoader = new GroovyClassLoader(sharedClassLoader, compilerConfig);
+		siteClassLoader.addClasspath(getPluginClassFullPath(siteId));
+		scriptEngine.setClassLoader(siteClassLoader);
+		return scriptEngine;
+	}
+
+	@EventListener
+	public void onSiteDeleting(SiteDeletingEvent event) {
+		removeScriptEngine(event.getSiteId());
+	}
+
+	protected void removeScriptEngine(String siteId) {
+		logger.debug("Remove the lifecycle Script Engine for site '{}'", siteId);
+		GroovyScriptEngineImpl removed = scriptEngines.remove(siteId);
+		if (removed != null) {
+			// Close the site child only; keep the shared parent classpath loader
+			GroovyClassLoaderUtils.closeQuietly(removed.getClassLoader(), sharedClassLoader);
 		}
 	}
 

--- a/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/scripting/ScriptEngineManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -15,21 +15,6 @@
  */
 package org.craftercms.studio.impl.v2.scripting;
 
-import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyResourceLoader;
-import groovy.util.GroovyScriptEngine;
-import groovy.util.ResourceConnector;
-import groovy.util.ResourceException;
-import org.codehaus.groovy.control.CompilerConfiguration;
-import org.craftercms.core.service.ContentStoreService;
-import org.craftercms.engine.util.url.ContentStoreUrlConnection;
-import org.craftercms.studio.api.v2.core.ContextManager;
-import org.craftercms.studio.api.v2.scripting.ScriptEngineManager;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
-import org.kohsuke.groovy.sandbox.SandboxTransformer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.beans.ConstructorProperties;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -38,6 +23,25 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.craftercms.core.service.ContentStoreService;
+import org.craftercms.engine.util.url.ContentStoreUrlConnection;
+import org.craftercms.studio.api.v2.core.ContextManager;
+import org.craftercms.studio.api.v2.event.site.SiteDeletingEvent;
+import org.craftercms.studio.api.v2.scripting.ScriptEngineManager;
+import org.craftercms.studio.impl.v2.utils.GroovyClassLoaderUtils;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.RejectASTTransformsCustomizer;
+import org.kohsuke.groovy.sandbox.SandboxTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyResourceLoader;
+import groovy.util.GroovyScriptEngine;
+import groovy.util.ResourceConnector;
+import groovy.util.ResourceException;
 
 /**
  * Default implementation of {@link ScriptEngineManager}
@@ -98,7 +102,22 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
 	@Override
 	public void reloadScriptEngine(String siteId) {
 		logger.debug("Reload the Script Engine for site '{}'", siteId);
-		scriptEngines.compute(siteId, (key, old) -> createScriptEngine(siteId));
+		scriptEngines.compute(siteId, (key, old) -> {
+			GroovyScriptEngine fresh = createScriptEngine(siteId);
+			if (old != null) {
+				GroovyClassLoaderUtils.closeQuietly(old.getGroovyClassLoader());
+			}
+			return fresh;
+		});
+	}
+
+	@EventListener
+	public void onSiteDeleting(SiteDeletingEvent event) {
+		logger.debug("Remove the Script Engine for site '{}'", event.getSiteId());
+		GroovyScriptEngine removed = scriptEngines.remove(event.getSiteId());
+		if (removed != null) {
+			GroovyClassLoaderUtils.closeQuietly(removed.getGroovyClassLoader());
+		}
 	}
 
 	// Internal classes used to load the scripts from the site

--- a/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
+++ b/src/main/java/org/craftercms/studio/impl/v2/utils/GroovyClassLoaderUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.studio.impl.v2.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import groovy.lang.GroovyClassLoader;
+
+/**
+ * Helpers for releasing {@link GroovyClassLoader} resources.
+ */
+public abstract class GroovyClassLoaderUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(GroovyClassLoaderUtils.class);
+
+	/**
+	 * Clear and close this classloader and any {@link GroovyClassLoader}
+	 * parents.
+	 *
+	 * @param classLoader the classloader to close (may be null)
+	 */
+	public static void closeQuietly(ClassLoader classLoader) {
+		closeQuietly(classLoader, null);
+	}
+
+	/**
+	 * Clear and close this classloader and {@link GroovyClassLoader} parents,
+	 * stopping before {@code stopAt}.
+	 *
+	 * @param classLoader the classloader to close (may be null)
+	 * @param stopAt parent to leave open; closing stops when this loader is
+	 * reached (exclusive). If null, stops at the first
+	 * non-{@link GroovyClassLoader} parent.
+	 */
+	public static void closeQuietly(ClassLoader classLoader, ClassLoader stopAt) {
+		while (classLoader instanceof GroovyClassLoader groovyClassLoader) {
+			if (classLoader == stopAt) {
+				break;
+			}
+			try {
+				groovyClassLoader.close();
+			} catch (Exception e) {
+				logger.warn("Failed to close Groovy class loader", e);
+			}
+			classLoader = classLoader.getParent();
+		}
+	}
+
+}


### PR DESCRIPTION
https://github.com/craftersoftware/craftercms/issues/1266
Use per-site classloaders for lifecycle Groovy scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Groovy script execution by reusing cached script engines per site, reducing repeated initialization overhead.

* **Reliability**
  * Enhanced resource cleanup by removing cached engines and releasing Groovy class loaders when sites are deleted or scripts are reloaded.
  * Added safer “close quietly” handling to avoid cleanup failures impacting normal operation.

* **Documentation**
  * Updated and clarified scripting-related Javadoc and refreshed copyright notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->